### PR TITLE
fail2ban fix

### DIFF
--- a/etc/nextcloudpi-config.d/fail2ban.sh
+++ b/etc/nextcloudpi-config.d/fail2ban.sh
@@ -56,8 +56,8 @@ service fail2ban start
 
 exit 0
 EOF
-    chmod +x /etc/services-available.d/100fail2ban
-  }
+
+  chmod +x /etc/services-available.d/100fail2ban
 
   # tweak fail2ban email 
   local F=/etc/fail2ban/action.d/sendmail-common.conf


### PR DESCRIPTION
Fix for #299
The issue was caused by [this update](https://github.com/Iolaum/nextcloudpi/commit/6b9699c870cf48458251095798544230fc7c3537#diff-996ed172e00fb26a6fad57660adc328d) on /etc/nextcloudpi-config.d/fail2ban.sh and results in fail2ban install process not fully completing because a remaining `}` ends `install` function prematurely.

P.S. Targeted master instead of devel branch because the commit with the bug is not present there but the image, from master, is out on the users.