### PR TITLE
Fixed configuration interoperability between nc-datadit and fail2ban.

### DIFF
--- a/etc/nextcloudpi-config.d/nc-datadir.sh
+++ b/etc/nextcloudpi-config.d/nc-datadir.sh
@@ -88,10 +88,11 @@ configure()
   sed -i "s|^opcache.file_cache=.*|opcache.file_cache=$DATADIR_/.opcache|" /etc/php/7.0/mods-available/opcache.ini
 
   # update fail2ban logpath
-  sed -i "s|logpath  =.*|logpath  = $DATADIR_/nextcloud.log|" /etc/fail2ban/jail.conf
+  sed -i "s|logpath  =.*nextcloud.log|logpath  = $DATADIR_/nextcloud.log|" /etc/fail2ban/jail.conf
 
   # datadir
   sudo -u www-data php occ config:system:set datadirectory --value="$DATADIR_"
+  sudo -u www-data php occ config:system:set logfile --value="$DATADIR_/nextcloud.log"
   sudo -u www-data php occ maintenance:mode --off
 }
 


### PR DESCRIPTION
Two changes that make setting a new data directory integrate better with setting up fail2ban.

First change is a modification in the `sed` command. The jail.conf file has two logfile lines. One for the ssh and another for the nextcloud instance. The previous version changed both of them. The new one only changes the one that is for nextcloud.

The second change specifies the log directory in `config.php` when the data directory is changed from the default one. If it is not specified the log file will by default be placed within the data directory. The problem is that when a user installs fail2ban **after** he has moved the data directory then [this line](https://github.com/nextcloud/nextcloudpi/blob/4f63c349ab3c3ab935dfb7a41c2f88e0adc9eac4/etc/nextcloudpi-config.d/fail2ban.sh#L80) will result in `NCLOG1=""`. This happens because when the logfile is not explicitly stated in `config.php` the command returns an empty string.