### PR TITLE
Change ping site to nextcloud.com (WAN connectivity check).

### DIFF
--- a/bin/ncp-check-version
+++ b/bin/ncp-check-version
@@ -4,7 +4,7 @@
 
 [ $(id -u) -ne 0 ] && exit 1
 
-ping  -W 2 -w 1 -q google.com &>/dev/null || { echo "No internet connectivity"; exit 1; }
+ping  -W 2 -w 1 -q nextcloud.com &>/dev/null || { echo "No internet connectivity"; exit 1; }
 
 rm -rf /tmp/ncp-check-tmp
 

--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -51,7 +51,7 @@ echo "Redis service|$( pgrep -c redis-server &>/dev/null && echo up || echo down
 echo "Postfix service|$( postfix status &>/dev/null && echo up || echo down )"
 
 # WAN
-echo "internet check|$( ping -W 2 -w 1 -q github.com &>/dev/null && echo ok || echo no } )"
+echo "internet check|$( ping -W 2 -w 1 -q nextcloud.com &>/dev/null && echo ok || echo no } )"
 
 function is_port_open()
 {

--- a/bin/ncp-update
+++ b/bin/ncp-update
@@ -4,7 +4,7 @@
 
 {
   [ "$(id -u)" -ne 0 ] && { printf "Must be run as root. Try 'sudo $0'\n"; exit 1; }
-  ping  -W 2 -w 1 -q google.com &>/dev/null || { echo "No internet connectivity"; exit 1; }
+  ping  -W 2 -w 1 -q nextcloud.com &>/dev/null || { echo "No internet connectivity"; exit 1; }
   echo -e "Downloading updates"
   rm -rf /tmp/ncp-update-tmp
   git clone --depth 20 -q https://github.com/nextcloud/nextcloudpi.git /tmp/ncp-update-tmp || exit 1

--- a/etc/nextcloudpi-config.d/letsencrypt.sh
+++ b/etc/nextcloudpi-config.d/letsencrypt.sh
@@ -57,7 +57,7 @@ EOF
 # tested with git version v0.11.0-71-g018a304
 configure() 
 {
-  ping  -W 2 -w 1 -q google.com &>/dev/null || { echo "No internet connectivity"; return 1; }
+  ping  -W 2 -w 1 -q nextcloud.com &>/dev/null || { echo "No internet connectivity"; return 1; }
 
   local DOMAIN_LOWERCASE="${DOMAIN_,,}"
 

--- a/etc/nextcloudpi-config.d/nc-nextcloud.sh
+++ b/etc/nextcloudpi-config.d/nc-nextcloud.sh
@@ -89,7 +89,7 @@ install()
 
 configure()
 {
-  ping -W 2 -w 1 -q google.com &>/dev/null || { echo "No internet connectivity"; return 1; }
+  ping -W 2 -w 1 -q nextcloud.com &>/dev/null || { echo "No internet connectivity"; return 1; }
 
   ## RE-CREATE DATABASE TABLE 
   echo "Starting mariaDB"

--- a/etc/nextcloudpi-config.d/no-ip.sh
+++ b/etc/nextcloudpi-config.d/no-ip.sh
@@ -88,7 +88,7 @@ configure()
   service noip2 stop
   [[ $ACTIVE_ != "yes" ]] && { update-rc.d noip2 disable; return 0; }
 
-  ping  -W 2 -w 1 -q google.com &>/dev/null || { echo "No internet connectivity"; return 1; echo "noip DDNS disabled"; }
+  ping  -W 2 -w 1 -q nextcloud.com &>/dev/null || { echo "No internet connectivity"; return 1; echo "noip DDNS disabled"; }
 
   local IF=$( ip -br l | awk '{ if ( $2 == "UP" ) print $1 }' | head -1 )
   [[ "$IF" != "" ]] && IF="-I $IF"


### PR DESCRIPTION
The connectivity check to WAN that was taking place in these 6 scripts was pinging to 'google.com' (5) and 'github.com' (1). github.com was having some issues in the past and I remember the change to google.com. Although in the issue #365 it is reported that google.com is blocked from China. So I changed it to 'nextcloud.com' which based on [this site](https://www.comparitech.com/privacy-security-tools/blockedinchina/) is not blocked in China.

I would agree to change 'nextcloud.com' to anything else if anyone finds it necessary. 