### PR TITLE
Don't overwrite an existing mail_smtpmode if it is not "PHP"

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -145,7 +145,10 @@ EOF
   }
 
   # NC14 doesnt support php mail
-  sudo -u www-data php /var/www/nextcloud/occ config:system:set mail_smtpmode --value="sendmail"
+  mail_smtpmode=$(sudo -u www-data php /var/www/nextcloud/occ config:system:get mail_smtpmode)
+  [[ $mail_smtpmode == "php" ]] && {
+    sudo -u www-data php /var/www/nextcloud/occ config:system:set mail_smtpmode --value="sendmail"
+  }
 
 } # end - only live updates
 


### PR DESCRIPTION
Overwriting the value `SMTP` is probably not the best idea. `SMTP` settings are done manually as required. They should not be disabled or overwritten.