### PR TITLE
(add function)Fix some errors that nextcloud will alert after the update.

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -166,7 +166,7 @@ echo "Fix permissions..."
 chown -R www-data:www-data nextcloud
 find nextcloud/ -type d -exec chmod 750 {} \;
 find nextcloud/ -type f -exec chmod 640 {} \;
-
+sudo -u www-data php /var/www/nextcloud/occ db:add-missing-indices
 # upgrade
 ####################
 echo "Upgrade..."

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -166,12 +166,11 @@ echo "Fix permissions..."
 chown -R www-data:www-data nextcloud
 find nextcloud/ -type d -exec chmod 750 {} \;
 find nextcloud/ -type f -exec chmod 640 {} \;
-sudo -u www-data php /var/www/nextcloud/occ db:add-missing-indices
 # upgrade
 ####################
 echo "Upgrade..."
 sudo -u www-data php nextcloud/occ upgrade      # && false # test point 
-
+sudo -u www-data php /var/www/nextcloud/occ db:add-missing-indices
 [[ -f nextcloud-old/.user.ini ]] && cp nextcloud-old/.user.ini nextcloud/
 
 # done


### PR DESCRIPTION
Fix some errors that nextcloud will alert after the update.

*****This is just one of my ideas and has not been tested. *****
After updating to NC14, the system will display security and other issues in the overview. If can fix the problem before the display, the user will be much more convenient.

Please ask the main developers to test, thank you.