### PR TITLE
check app compatibility before before executing NC update

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -65,40 +65,54 @@ echo "Available Nextcloud version $VER"
 # app compatibility check
 ##########################
 
-incompatible_apps=""
-for app_info in /var/www/nextcloud/apps/*/appinfo/info.xml
-do
-  version_xml=$(grep "$app_info" -e '< *nextcloud *min-version="[0-9][0-9]*" *max-version="[0-9][0-9]*" */>' | tr -d "\n")
-  for word in $version_xml
-  do
-    #echo "$word"
-    min_grep=$(echo $word | grep "min-version" | sed "s/min-version=\"//" | sed "s/\"//")
-    max_grep=$(echo $word | grep "max-version" | sed "s/max-version=\"//" | sed "s/\"//")
+incompatibleApps=""
 
-    if [ "$min_grep" != "" ];
-    then
-      min_version="$min_grep"
+#for a in a b c; do echo $a; done
+for jsonWord in $(ncc app:list --output="json_pretty" | grep \"disabled\": -B5000 | grep "        ")
+do
+  appQuoteStripped=${jsonWord//\"}
+  app=${appQuoteStripped//:} 
+
+  # if      line ends in ':'      and      app directory exist -> app is valid; else skip current app
+  [[ -z "${appQuoteStripped##*:}" && -d "/var/www/nextcloud/apps/$app" ]]       || continue
+
+  appDir=nextcloud/apps/$app
+  appInfoPath=$appDir/appinfo/info.xml
+  [[ -f "$appInfoPath" ]] || { echo "ERROR: info.xml not found for $app (searching in '$appInfoPath')!"; exit 1; }
+
+  versionXML=$(grep "$appInfoPath" -e '< *nextcloud *min-version="[0-9][0-9]*" *max-version="[0-9][0-9]*" */>' | tr -d "\n")
+  for word in $versionXML
+  do
+    minGrep=$(grep -o 'min-version="[0-9][0-9]*"' <<< $word | sed "s/min-version=\"//")
+    maxGrep=$(grep -o 'max-version="[0-9][0-9]*"' <<< $word | sed "s/max-version=\"//")
+    
+    if [[ ! -z "$minGrep" ]]; then
+      minVersion="${minGrep//\"}"
     fi
-    if [ "$max_grep" != "" ];
-    then
-      max_version="$max_grep"
+    if [[ ! -z "$maxGrep" ]]; then
+      maxVersion="${maxGrep//\"}"
     fi
+
   done
-  if [ "$MAJOR" -lt "$min_version" ] || [ "$MAJOR" -gt "$max_version" ]; then
-    app_dir=$(dirname $app_info)
-    app_dir=$(dirname $app_dir)
-    app=$(basename $app_dir)
-    incompatible_apps="$incompatible_apps, $app (requires NC $min_version-$max_version)"
-    #echo App: $app
-    #echo $version_xml
-    echo Supported NC versions: $min_version - $max_version
+
+  # verify min and max version are numbers
+  [[ ! -z "$minVersion" && ! -z "$maxVersion" && "$minVersion" -eq "$minVersion" && "$maxVersion" -eq "$maxVersion" ]] || {
+    echo "ERROR: Malformed compatibility info (min/max version) for app '$app'!"
+    exit 1 
+  }
+
+  if [[ "$MAJOR" -lt "$minVersion" || "$MAJOR" -gt "$maxVersion" ]]; then
+    incompatibleApps="$incompatibleApps$app (requires NC $minVersion-$maxVersion), "
   fi
+
 done
 
-if [ "$incompatible_apps" != "" ];
+if [ "$incompatibleApps" != "" ]; then
   echo "1 or more apps are not compatible with the latest Nextcloud version! Update will be held back..."
-  echo "Not compatible: $incompatible_apps"
+  echo "Not compatible: ${incompatibleApps%, }"
   exit 1
+else
+  echo "All apps are compatible with the new NC version. Proceeding..."
 fi
 
 

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -61,6 +61,47 @@ echo "Current   Nextcloud version $CURRENT"
 echo "Available Nextcloud version $VER"
 [[ "$NEED_UPDATE" == "true" ]] || { echo "Nothing to update"; exit 1; }
 
+
+# app compatibility check
+##########################
+
+incompatible_apps=""
+for app_info in /var/www/nextcloud/apps/*/appinfo/info.xml
+do
+  version_xml=$(grep "$app_info" -e '< *nextcloud *min-version="[0-9][0-9]*" *max-version="[0-9][0-9]*" */>' | tr -d "\n")
+  for word in $version_xml
+  do
+    #echo "$word"
+    min_grep=$(echo $word | grep "min-version" | sed "s/min-version=\"//" | sed "s/\"//")
+    max_grep=$(echo $word | grep "max-version" | sed "s/max-version=\"//" | sed "s/\"//")
+
+    if [ "$min_grep" != "" ];
+    then
+      min_version="$min_grep"
+    fi
+    if [ "$max_grep" != "" ];
+    then
+      max_version="$max_grep"
+    fi
+  done
+  if [ "$MAJOR" -lt "$min_version" ] || [ "$MAJOR" -gt "$max_version" ]; then
+    app_dir=$(dirname $app_info)
+    app_dir=$(dirname $app_dir)
+    app=$(basename $app_dir)
+    incompatible_apps="$incompatible_apps, $app (requires NC $min_version-$max_version)"
+    #echo App: $app
+    #echo $version_xml
+    echo Supported NC versions: $min_version - $max_version
+  fi
+done
+
+if [ "$incompatible_apps" != "" ];
+  echo "1 or more apps are not compatible with the latest Nextcloud version! Update will be held back..."
+  echo "Not compatible: $incompatible_apps"
+  exit 1
+fi
+
+
 # make sure that cron.php is not running and there are no pending jobs
 # https://github.com/nextcloud/server/issues/10949
 pgrep -cf cron.php &>/dev/null && { pkill -f cron.php; sleep 3; }


### PR DESCRIPTION
This PR implements the following:

1) check supported versions of all enabled NC apps for compatibility with the new version before an update
2) if incompatible apps are found, write their names and version requirements to the logs and abort the update

There is one potential issue with the update check: It's executed pre-update, that means, if an app does not support the next NC version, but it's update (which would support the next version) does not support the current NC version, there is no way for the updater to succeed.
Example: Assuming the currently supported version of the news app supports NC 12-14 and NC 15 is going to be installed. There is an update to the news app, which adds support for NC 15 but does not support any previous version. This will cause the update to not be able to resolve (not even after manual app updates).

However I don't think that this case is very likely to occur. It could be avoided by doing the app compatibility check *after* the NC update has been executed and restoring the backup if any apps are not compatible - however I think this would be an additional source of errors, that isn't really worth it.