### PR TITLE
nc-rsync.sh: sync datadir, not only content (#686)

### DIFF
--- a/etc/ncp-config.d/nc-rsync.sh
+++ b/etc/ncp-config.d/nc-rsync.sh
@@ -32,7 +32,7 @@ configure()
     return 1;
   }
 
-  rsync -aAx --delete "$DATADIR"/ "$DESTINATION_"
+  rsync -aAx --delete "$DATADIR" "$DESTINATION_"
 
   sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --off
 }


### PR DESCRIPTION
Changed rsync command to behave like nc-rsync-auto - as proposed in issue #686.