### PR TITLE
Removed redundant php7.2 opcache configuration.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -213,6 +213,10 @@ Pin-Priority: 600
 EOF
   fi
 
+  # remove redundant opcache configuration. Leave until update bug is fixed -> https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=815968
+  # Bug #416 reappeared after we moved to php7.2 and debian buster packages.
+  [[ "$( ls -l /etc/php/7.2/fpm/conf.d/*-opcache.ini |  wc -l )" -gt 1 ]] && rm "$( ls /etc/php/7.2/fpm/conf.d/*-opcache.ini | tail -1 )"
+  [[ "$( ls -l /etc/php/7.2/cli/conf.d/*-opcache.ini |  wc -l )" -gt 1 ]] && rm "$( ls /etc/php/7.2/cli/conf.d/*-opcache.ini | tail -1 )"
 
 } # end - only live updates
 


### PR DESCRIPTION
Bug #416 reappeared after we moved to php7.2 and buster sources.

P.S. 
I think this happened after 26083e9b753c564fe37fd0927c5ef36d0cd4bdb1 but I am not 100% sure.