### PR TITLE
fix: adapt DATADIR variable for prober nc-backup operation inside docker

### DIFF
--- a/etc/ncp-config.d/nc-backup.sh
+++ b/etc/ncp-config.d/nc-backup.sh
@@ -61,7 +61,7 @@ FREE=$( df    "$DESTDIR" | tail -1 | awk '{ print $4 }' )
 
 # database
 $OCC maintenance:mode --on
-[[ -f /.docker-image ]] && mv /data/app /data/nextcloud
+[[ -f /.docker-image ]] && mv /data/app /data/nextcloud && DATADIR=/data/nextcloud/data
 [[ -f /.docker-image ]] && BASEDIR=/data || BASEDIR=/var/www
 cd "$BASEDIR" || exit 1
 echo "backup database..."


### PR DESCRIPTION
As mentioned in [#685](https://github.com/nextcloud/nextcloudpi/issues/685#issuecomment-448632028) there is an inconsistency in the directory paths. 
I propose now another solution that will only affect the code if it is called inside docker.

For the `nextcloudpi-x86` configuration it is working and verified. 