### PR TITLE
Update the systems data-fingerprint after restoration

### DIFF
--- a/etc/ncp-config.d/nc-restore.sh
+++ b/etc/ncp-config.d/nc-restore.sh
@@ -161,6 +161,9 @@ sed -i "s|^;\?sys_temp_dir =.*$|sys_temp_dir = $DATADIR/tmp|"     /etc/php/${PHP
 # refresh nextcloud trusted domains
 bash /usr/local/bin/nextcloud-domain.sh
 
+# update the systems data-fingerprint
+sudo -u www-data php occ maintenance:data-fingerprint
+
 # restart PHP if needed
 [[ "$NEED_RESTART" == "1" ]] && \
   bash -c " sleep 3; service php${PHPVER}-fpm restart" &>/dev/null &


### PR DESCRIPTION
Admin manual:

> After restoring a backup of your data directory or the database, you should always call `maintenance:data-fingerprint` once. This changes the ETag for all files in the communication with sync clients, allowing them to realize a file was modified.