### PR TITLE
Proposed fix for issue #773

### DIFF
--- a/docker-common/debian-ncp/run-parts.sh
+++ b/docker-common/debian-ncp/run-parts.sh
@@ -38,12 +38,12 @@ EOF
 chmod +x /usr/local/sbin/update-rc.d
 
 # Iterate only over 000* entries which might setup environment
-for file in $( ls -1v /etc/services-enabled.d | grep 000* ); do
+for file in $( ls -1v /etc/services-enabled.d | grep ^000.* ); do
   /etc/services-enabled.d/"$file" start "$1"
 done
 
 # Iterate over remaining entries
-for file in $( ls -1v -I 000* /etc/services-enabled.d ); do
+for file in $( ls -1v /etc/services-enabled.d | grep -v ^000.* ); do
   /etc/services-enabled.d/"$file" start "$1"
 done
 


### PR DESCRIPTION
Proposed fix for issue #773. To recap:

> The regular expression on line 41 of `/run-parts.sh` appears to be incorrect: `grep 000*` will match any string contain either 000 _or_ 00. This means that when dnsmasq is enabled, for example, the startup service gets run twice, once after `000ncp` (which seems to be incorrect), and once with the other services (which appears to be the intention).

The changes here:

1. Fix this regular expression so that _only_ services starting with 000 are run during the setup phase, and

2. Tweak the process for identifying all other enabled services to parallel this first change.

I have been running this change "in production" on my personal NextCloudPi server for a bit over a week now, with no observable issues or errors.

(FWIW, this is the first pull request I've ever done. Please let me know if there's something else that I need to do here.)