### PR TITLE
Proposed fix for issue #772

### DIFF
--- a/bin/ncp/NETWORKING/dnsmasq.sh
+++ b/bin/ncp/NETWORKING/dnsmasq.sh
@@ -49,7 +49,8 @@ configure()
   }
 
   local IFACE=$( ip r | grep "default via"   | awk '{ print $5 }' | head -1 )
-  local IP=$( ip a show dev "$IFACE" | grep global | grep -oP '\d{1,3}(.\d{1,3}){3}' | head -1 )
+  local IP=$( sudo -u www-data php /var/www/nextcloud/occ config:system:get trusted_domains 6 | grep -oP '\d{1,3}(.\d{1,3}){3}' )
+  [[ "$IP" == "" ]] && IP=$( ip a show dev "$IFACE" | grep global | grep -oP '\d{1,3}(.\d{1,3}){3}' | head -1 )
 
   [[ "$IP" == "" ]] && { echo "could not detect IP"; return 1; }
   


### PR DESCRIPTION
Proposed fix for issue #772. To recap:

> Right now, enabling `dnsmasq` within a NextCloudPi Docker container associates your `$DOMAIN` with the container's _private_ IP address. This means that Docker images cannot [use `dnsmasq` to redirect systems on your home network to your NextCloudPi server](https://ownyourbits.com/2017/03/09/dnsmasq-as-dns-cache-server-for-nextcloudpi-and-raspbian/).

This change sets the IP address corresponding to your Nextcloud `$DOMAIN` to the IP (optionally) passed into the docker image (which is stored by `020nextcloud` in `trusted_domains 6`). If `trusted_domains 6` is empty or is not an IP address, fall back to the previous behavior.

Tested on my "production" home NextCloudPi server. Note that I only have access to that server and a Chromebook right now, so my ability to test this change more fully is limited.