### PR TITLE
Fixed warning + update prompt in ncp-config

### DIFF
--- a/bin/ncp-config
+++ b/bin/ncp-config
@@ -15,12 +15,12 @@ BINDIR=/usr/local/bin/ncp
 
 source /usr/local/etc/library.sh
 {
-  local latest_ver="$(cat /var/run/.ncp-latest-version)"
-  local ncpversion="$(cat /usr/local/etc/ncp-version  )"
-  local chlogfile=/usr/local/etc/ncp-changelog
+  latest_ver="$(cat /var/run/.ncp-latest-version)"
+  ncpversion="$(cat /usr/local/etc/ncp-version  )"
+  chlogfile=/usr/local/etc/ncp-changelog
   # ask for update if outdated
   ncp-test-updates 2>/dev/null && {
-    [[ -f "$chlogfile" ]] && local changelog=$( head -4 "$chlogfile" )
+    [[ -f "$chlogfile" ]] && changelog=$( head -4 "$chlogfile" )
 
     whiptail --backtitle "$backtitle $ncpversion" \
              --title "NextCloudPi update available" \


### PR DESCRIPTION
This fixes some warning reported on [a comment in one of my previous issues](https://github.com/nextcloud/nextcloudpi/issues/784#issuecomment-457483813). That said, this looks like a separate issue from what I reported.

Incidentally, this also makes the update prompt in `ncp-config` work for me (which it hadn't previously, but wasn't a big deal from my perspective).

I've _lightly_ tested this change on my own server, and haven't detected any bad consequences, but it's not 100% clear to me how much isolation you're trying to achieve here or if this tweak might break something subtle.