### PR TITLE
nc-rsync: choose ssh port other than 22 (#564)

### DIFF
--- a/bin/ncp/BACKUPS/nc-rsync-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-auto.sh
@@ -34,7 +34,7 @@ configure()
     ${SSH[@]} : || { echo "SSH non-interactive not properly configured"; return 1; }
   }
 
-  echo "0  5  */${SYNCDAYS}  *  *  root  /usr/bin/rsync -ax --delete \"$DATADIR\" \"$DESTINATION\"" > /etc/cron.d/ncp-rsync-auto
+  echo "0  5  */${SYNCDAYS}  *  *  root  /usr/bin/rsync -ax -e \"ssh -p $PORTNUMBER\" --delete \"$DATADIR\" \"$DESTINATION\"" > /etc/cron.d/ncp-rsync-auto
   chmod 644 /etc/cron.d/ncp-rsync-auto
   service cron restart
 

--- a/bin/ncp/BACKUPS/nc-rsync.sh
+++ b/bin/ncp/BACKUPS/nc-rsync.sh
@@ -26,7 +26,7 @@ configure()
     return 1;
   }
 
-  rsync -ax --delete "$DATADIR" "$DESTINATION"
+  rsync -ax -e "ssh -p $PORTNUMBER" --delete "$DATADIR" "$DESTINATION"
 
   sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --off
 }

--- a/etc/ncp-config.d/nc-rsync-auto.cfg
+++ b/etc/ncp-config.d/nc-rsync-auto.cfg
@@ -19,6 +19,12 @@
       "suggest": "user@ip:/path/to/sync"
     },
     {
+      "id": "PORTNUMBER",
+      "name": "SSH port number",
+      "value": "22",
+      "suggest": "22"
+    },
+    {
       "id": "SYNCDAYS",
       "name": "Sync days",
       "value": "3",

--- a/etc/ncp-config.d/nc-rsync.cfg
+++ b/etc/ncp-config.d/nc-rsync.cfg
@@ -11,6 +11,12 @@
       "name": "Destination",
       "value": "user@ip:/path/to/sync",
       "suggest": "user@ip:/path/to/sync"
+    },
+    {
+      "id": "PORTNUMBER",
+      "name": "SSH port number",
+      "value": "22",
+      "suggest": "22"
     }
   ]
 }


### PR DESCRIPTION
This will allow the user to enter a ssh port number for rsync other than 22. Tried it with my external storage box that only allows connections over port 23. Not tested is the automatic rsync and also I'm not sure if the port causes problems for users that want to rsync to a local folder. 