### PR TITLE
New features: Turn maintenance mode on or off

### DIFF
--- a/bin/ncp/TOOLS/nc-maintenance.sh
+++ b/bin/ncp/TOOLS/nc-maintenance.sh
@@ -12,10 +12,10 @@
 configure()
 {
   [[ $ACTIVE != "yes" ]] && {
-    sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
+    ncc --off
     return 0 
   }
-  sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on 
+  ncc --on 
 }
 
 # License

--- a/bin/ncp/TOOLS/nc-maintenance.sh
+++ b/bin/ncp/TOOLS/nc-maintenance.sh
@@ -12,10 +12,10 @@
 configure()
 {
   [[ $ACTIVE != "yes" ]] && {
-    ncc --off
+    ncc maintenance:mode --off
     return 0 
   }
-  ncc --on 
+  ncc maintenance:mode --on 
 }
 
 # License

--- a/bin/ncp/TOOLS/nc-maintenance.sh
+++ b/bin/ncp/TOOLS/nc-maintenance.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Turn maintenance mode on or off
+#
+# Copyleft 2019 by Yi Chi 齊一 <chiyi4869 _a_t_ gmail _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://www.cotpear.com
+# Made in Taiwan (Republic of China)
+#
+
+configure()
+{
+  [[ $ACTIVE != "yes" ]] && {
+    sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
+    return 0 
+  }
+  sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on 
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/etc/ncp-config.d/nc-maintenance.cfg
+++ b/etc/ncp-config.d/nc-maintenance.cfg
@@ -3,12 +3,12 @@
   "name": "Nc-maintenanceMode",
   "title": "nc-maintenance-mode",
   "description": "Turn maintenance mode on or off",
-  "info": "Open maintenance mode (ACTIVE=yes), or close maintenance mode  (ACTIVE=no)",
+  "info": "Open maintenance mode (ACTIVE=yes), or close maintenance mode (ACTIVE=no)",
   "infotitle": "",
   "params": [
     {
       "id": "ACTIVE",
-      "name": "Active",
+      "name": "Enabled",
       "value": "no",
       "type": "bool"
     } 

--- a/etc/ncp-config.d/nc-maintenance.cfg
+++ b/etc/ncp-config.d/nc-maintenance.cfg
@@ -1,0 +1,16 @@
+{
+  "id": "nc-maintenance",
+  "name": "Nc-maintenanceMode",
+  "title": "nc-maintenance-mode",
+  "description": "Turn maintenance mode on or off",
+  "info": "Open maintenance mode (ACTIVE=yes), or close maintenance mode  (ACTIVE=no)",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "ACTIVE",
+      "name": "Active",
+      "value": "no",
+      "type": "bool"
+    } 
+  ]
+}


### PR DESCRIPTION
This feature is designed for users who are just using nextcloud and can simply troubleshoot problems (such as accidentally opening maintenance mode when updating).

Thanks