### PR TITLE
Show the user more infos when backup the datadir

### DIFF
--- a/bin/ncp/BACKUPS/nc-restore.sh
+++ b/bin/ncp/BACKUPS/nc-restore.sh
@@ -95,7 +95,7 @@ if [[ $( ls "$TMPDIR" | wc -l ) -eq $NUMFILES ]]; then
   echo "restore datadir to $DATADIR..."
 
   [[ -e "$DATADIR" ]] && { 
-    echo "backing up existing $DATADIR"
+    echo "backing up existing $DATADIR to $DATADIR-$( date "+%m-%d-%y" )..."
     mv "$DATADIR" "$DATADIR-$( date "+%m-%d-%y" )" || exit 1
   }
 


### PR DESCRIPTION
Recently I did a restore for the first time, by using NCP.
While I was reading that NCP is doing a backup (when I clicked "Restore a previously backuped NC instance"), I asked myself:
"Where will this backup be written to?"

This patch shows the user this info.

TanarRi