### PR TITLE
 Inform the user about the current step

### DIFF
--- a/bin/ncp/BACKUPS/nc-restore.sh
+++ b/bin/ncp/BACKUPS/nc-restore.sh
@@ -92,13 +92,13 @@ if [[ $( ls "$TMPDIR" | wc -l ) -eq $NUMFILES ]]; then
   DATADIR=$( grep datadirectory "$NCDIR"/config/config.php | awk '{ print $3 }' | grep -oP "[^']*[^']" | head -1 ) 
   [[ "$DATADIR" == "" ]] && { echo "Error reading data directory"; exit 1; }
 
-  echo "restore datadir to $DATADIR..."
-
   [[ -e "$DATADIR" ]] && { 
     echo "backing up existing $DATADIR to $DATADIR-$( date "+%m-%d-%y" )..."
     mv "$DATADIR" "$DATADIR-$( date "+%m-%d-%y" )" || exit 1
   }
 
+  echo "restore datadir to $DATADIR..."
+  
   mkdir -p "$DATADIR"
   [[ "$( stat -fc%T "$DATADIR" )" == "btrfs" ]] && {
     rmdir "$DATADIR"                  || exit 1


### PR DESCRIPTION
In case of restore a big nextcloud instance the current infos, showed the user is missleading.
Think of the steps:
1) echo "restore datadir to $DATADIR..." (info to the user)
2)  echo "backing up existing $DATADIR to $DATADIR-$( date "+%m-%d-%y" )..." (--> Info for the user: a backup is performed. Because it only renames a directory the move will last only 1 second)
3) ..no more infos for the user.... the user think: Well, the step 2 lasts a llooonnngggg time.... But the program is doing the real restore of the $DATADIR

--> moved the "echo" a few lines down...

TanarRi