### PR TITLE
Small typo

### DIFF
--- a/etc/ncp-config.d/SSH.cfg
+++ b/etc/ncp-config.d/SSH.cfg
@@ -3,7 +3,7 @@
   "name": "SSH OpenSSH is a remote login program",
   "title": "SSH",
   "description": "Activate or deactivate SSH - OpenSSH is a remote login program",
-  "info": "In order to enable SSH, the password for user 'pi' can NOT remain set to the default raspberry. \nYou HAVE to create a NEW password for 'pi' if you want this program to enable SSH, it will fail if you dont!\nThe same will happen with user 'root' and password '1234'\nNote: Use normal AlphaNumeric, the only special characters allowed are .,@-_/",
+  "info": "In order to enable SSH, the password for user 'pi' can NOT remain set to the default 'raspberry'. \nYou HAVE to create a NEW password for 'pi' if you want this program to enable SSH, it will fail if you dont!\nThe same will happen with user 'root' and password '1234'\nNote: Use normal AlphaNumeric, the only special characters allowed are .,@-_/",
   "infotitle": "SSH notes",
   "params": [
     {


### PR DESCRIPTION
'raspberry' is the password, and I think it should be quoted for better reading - like 'pi' a few words before in the same line.