### PR TITLE
Clarify usage

### DIFF
--- a/etc/ncp-config.d/nc-passwd.cfg
+++ b/etc/ncp-config.d/nc-passwd.cfg
@@ -3,7 +3,7 @@
   "name": "Nc-passwd",
   "title": "nc-passwd",
   "description": "Change password for the NextCloudPi Panel",
-  "info": "",
+  "info": "Please note some special characters are not allowed here, avoid using ) } ; # in password",
   "infotitle": "",
   "params": [
     {


### PR DESCRIPTION
Found a few reference https://github.com/nextcloud/nextcloudpi/issues/155 
to issues with special characters in passwords, also with german umlaut ".
Which ones are sanitized? and need to be added to "info" or should it be in "description"?
I will also add it to Config-Reference, once established which characters to avoid ;-)