### PR TITLE
Adjust naming of "data dir" to "data directory" to be consistent

### DIFF
--- a/bin/ncp/CONFIG/nc-datadir.sh
+++ b/bin/ncp/CONFIG/nc-datadir.sh
@@ -68,7 +68,7 @@ configure()
   cd /var/www/nextcloud
   sudo -u www-data php occ maintenance:mode --on
 
-  echo "moving data dir from $SRCDIR to $DATADIR..."
+  echo "moving data directory from $SRCDIR to $DATADIR..."
 
   # use subvolumes, if BTRFS
   [[ "$( stat -fc%T "$BASEDIR" )" == "btrfs" ]] && {

--- a/bin/ncp/TOOLS/nc-fix-permissions.sh
+++ b/bin/ncp/TOOLS/nc-fix-permissions.sh
@@ -13,7 +13,7 @@ configure()
 {
   local DATADIR
   DATADIR=$( cd /var/www/nextcloud; sudo -u www-data php occ config:system:get datadirectory ) || {
-    echo "data dir not found";
+    echo "data directory not found";
     return 1;
   }
   echo -ne "fixing permissions in $DATADIR... "

--- a/bin/ncp/TOOLS/nc-previews.sh
+++ b/bin/ncp/TOOLS/nc-previews.sh
@@ -14,7 +14,7 @@ configure()
   [[ "$CLEAN" == "yes" ]] && {
     local datadir
     datadir=$( ncc config:system:get datadirectory ) || {
-      echo "data dir not found";
+      echo "data directory not found";
       return 1;
     }
 


### PR DESCRIPTION
Sometimes "data dir" will be used to inform the user - and sometimes "data directory"

This will fix this, that "data directory"consistently be used.