### PR TITLE
Replace links from github wiki to docs.nextcloudpi.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Check this wiki article if you want to learn how you can help.
 
-[Ways to contribute](https://github.com/nextcloud/nextcloudpi/wiki/Contribute)
+[Ways to contribute](http://docs.nextcloudpi.com/en/latest/Maintain/Contribute/)
 
 Check this other article to learn about the process of contributing with code and with testing.
 
-[NCP Feature Workflow](https://github.com/nextcloud/nextcloudpi/wiki/Workflow-and-testing-of-new-features)
+[NCP Feature Workflow](http://docs.nextcloudpi.com/en/latest/Maintain/Workflow-and-testing-of-new-features/)


### PR DESCRIPTION
The CONTRIBUTING.md file links were pointing to the old wiki on github.
Based on the URL I replaced them with the links from docs.nextcloudpi.com.

I was wondering if is possible to do pull requests for the doc.nextcloudpi.com as well?
If yes, maybe a link could be added in this file.

Thank you