### PR TITLE
Updated spDYN.sh

### DIFF
--- a/bin/ncp/NETWORKING/spDYN.sh
+++ b/bin/ncp/NETWORKING/spDYN.sh
@@ -10,8 +10,7 @@
 #
 
 
-INSTALLDIR=spdnsupdater
-INSTALLPATH=/usr/local/etc/$INSTALLDIR
+INSTALLPATH=/usr/local/bin
 CRONFILE=/etc/cron.d/spdnsupdater
 
 install()
@@ -24,8 +23,7 @@ install()
 
 ### Usage
 #
-#	Recommended usage:	./spdnsUpdater.sh <hostname> <token>
-#	Alternative usage:	./spdnsUpdater.sh <hostname> <user> <passwd> (not implemented)
+#	Recommended usage:	./spdnsUpdater.sh <hostname> <token> <IPv6 yes/no>
 #
 
 ### Configuration


### PR DESCRIPTION
- As suggested by nachoparker in https://help.nextcloud.com/t/spdyn-updater-not-working/32199/26 over a year ago, I finally adjusted the setup script to put the bash file into `/usr/local/bin/` instead of `/usr/local/etc`.
- Also I adjusted the "Usage" section a bit to fit ncp usage with IPv6

I think, that should be better :)