### PR TITLE
nc-restore.cfg: default values for BACKUPFILE

### DIFF
--- a/etc/ncp-config.d/nc-restore.cfg
+++ b/etc/ncp-config.d/nc-restore.cfg
@@ -1,1 +1,17 @@
-{"id":"nc-restore","name":"Nc-restore","title":"nc-restore","description":"Restore a previously backuped NC instance","info":"This new installation will cleanup current\nNextCloud instance, including files and database.\n\n** perform backup before proceding **\n\nYou can use 'nc-backup'","infotitle":"Restore NextCloud backup","params":[{"id":"BACKUPFILE","name":"Backup file","value":"\/tmp\/nextcloud-bkp_20190407_1554680888.tar.gz","suggest":"\/media\/USBdrive\/ncp-backups\/nextcloud-bkp_xxxxxxxx.tar","type":"file"}]}
+{
+  "id": "nc-restore",
+  "name": "Nc-restore",
+  "title": "nc-restore",
+  "description": "Restore a previously backuped NC instance",
+  "info": "This new installation will cleanup current\nNextCloud instance, including files and database.\n\n** perform backup before proceding **\n\nYou can use 'nc-backup'",
+  "infotitle": "Restore NextCloud backup",
+  "params": [
+    {
+      "id": "BACKUPFILE",
+      "name": "Backup file",
+      "value": "/media/USBdrive/ncp-backups/nextcloud-bkp_xxxxxxxx.tar",
+      "suggest": "/media/USBdrive/ncp-backups/nextcloud-bkp_xxxxxxxx.tar",
+      "type": "file"
+    }
+  ]
+}


### PR DESCRIPTION
It seems the default values are out of a test-installation and the formating got lost.
Correct this to the previous values.