### PR TITLE
nc-automount.cfg: Update description

### DIFF
--- a/etc/ncp-config.d/nc-automount.cfg
+++ b/etc/ncp-config.d/nc-automount.cfg
@@ -3,7 +3,7 @@
   "name": "Nc-automount",
   "title": "nc-automount",
   "description": "Automount USB drives by plugging them in",
-  "info": "Plugged in USB drives will be automounted under /media\non boot or at the moment of insertion.\n\nFormat your drive as ext4/btrfs in order to move NC datafolder or database\nVFAT or NTFS is not recommended for this task, as it does not suport permissions\n\nIMPORTANT: halt or umount the drive before extracting",
+  "info": "Plugged in USB drives will be automounted under /media\non boot or at the moment of insertion.\n\nFormat your drive as ext4/btrfs in order to move NC datafolder or database\nVFAT or NTFS is not recommended for this task, as it does not suport permissions\n\nIMPORTANT: halt or umount the drive before removing",
   "infotitle": "Automount notes",
   "params": [
     {


### PR DESCRIPTION
I think it should be "removing", because "extraction" make no sense in automounting