### PR TITLE
removing unused IPV6 argument in spDYN.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Check this wiki article if you want to learn how you can help.
 
-[Ways to contribute](http://docs.nextcloudpi.com/en/latest/Maintain/Contribute/)
+[Ways to contribute](https://docs.nextcloudpi.com/en/contribute/)
 
 Check this other article to learn about the process of contributing with code and with testing.
 
-[NCP Feature Workflow](http://docs.nextcloudpi.com/en/latest/Maintain/Workflow-and-testing-of-new-features/)
+[NCP Feature Workflow](https://docs.nextcloudpi.com/en/workflow-and-testing-of-new-features/)

--- a/bin/ncp/BACKUPS/nc-backup.sh
+++ b/bin/ncp/BACKUPS/nc-backup.sh
@@ -85,7 +85,7 @@ tar $compress_arg -cf "$destfile" \
     --exclude "$data/.opcache" \
     --exclude "$data/{access,error,nextcloud}.log" \
     --exclude "$data/access.log" \
-    --exclude "$data/ncp-update-backups/" \
+    --exclude "$data/ncp-update-backups" \
     -C "$(dirname "$datadir"/)" $data \
 \
     --exclude "nextcloud/data/*/files/*" \
@@ -93,7 +93,7 @@ tar $compress_arg -cf "$destfile" \
     --exclude "nextcloud/data/{access,error,nextcloud}.log" \
     --exclude "nextcloud/data/access.log" \
     --exclude "nextcloud/data/appdata_*/previews/*" \
-    --exclude "nextcloud/data/ncp-update-backups/" \
+    --exclude "nextcloud/data/ncp-update-backups" \
     -C $basedir nextcloud/ \
   || {
         echo "error generating backup"

--- a/bin/ncp/NETWORKING/spDYN.sh
+++ b/bin/ncp/NETWORKING/spDYN.sh
@@ -31,14 +31,9 @@ install()
 ### Configuration
 HOST=$1
 TOKEN=$2
-IPv6=$3
 
 # Get current IP address from
-if [[ $IPv6 == "yes" ]];	then
-	get_ip_url="http://checkip6.spdyn.de"
-else
-	get_ip_url="http://checkip4.spdyn.de"
-fi
+get_ip_url="http://checkip.spdyn.de"
 
 update_url="https://update.spdyn.de/nic/update"
 
@@ -100,11 +95,11 @@ configure()
     
     # Adds file to cron to run script for DNS record updates and change permissions
     touch $CRONFILE
-    echo "10 * * * * root $INSTALLPATH/spdnsUpdater.sh $DOMAIN $TOKEN $IPv6 >/dev/null 2>&1" > "$CRONFILE"
+    echo "10 * * * * root $INSTALLPATH/spdnsUpdater.sh $DOMAIN $TOKEN >/dev/null 2>&1" > "$CRONFILE"
     chmod 644 "$CRONFILE"
 
     # First-time execution of update script and print response from spdns.de server
-    "$INSTALLPATH"/spdnsUpdater.sh "$DOMAIN" "$TOKEN" "$IPv6"
+    "$INSTALLPATH"/spdnsUpdater.sh "$DOMAIN" "$TOKEN"
 		
 		echo -e "\nspdnsUpdater is now enabled"
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 
-[v1.13.2](https://github.com/nextcloud/nextcloudpi/commit/270ae92) (2019-06-03) fix upgrade
+[v1.13.2](https://github.com/nextcloud/nextcloudpi/commit/c24b3a3) (2019-06-17) nc-backup: fix exclusion of ncp backups
 
-[v1.13.1](https://github.com/nextcloud/nextcloudpi/commit/5de855f) (2019-06-01) ncp-web: avoid quotes in fields
+[v1.13.1 ](https://github.com/nextcloud/nextcloudpi/commit/5de855f) (2019-06-01) ncp-web: avoid quotes in fields
 
-[v1.13.0](https://github.com/nextcloud/nextcloudpi/commit/86f14ae) (2019-06-01) upgrade to NC15.0.8
+[v1.13.0 ](https://github.com/nextcloud/nextcloudpi/commit/86f14ae) (2019-06-01) upgrade to NC15.0.8
 
 [v1.12.10](https://github.com/nextcloud/nextcloudpi/commit/5924131) (2019-06-01) fail2ban: fix missing ufw filter
 


### PR DESCRIPTION
Since #883 is still open and I run into the same problems with spdyn (which took me quite some time to figure out what was going wrong), maybe another take helps to resolve the bug (more quickly).

Right now the `IPv6` argument in the spdnsUpdater.sh script (created using spDYN.sh) is not covered by whiptail. This causes raspis having only a IPv6 address to be unable to updated their dynamic ip address provided by spdyn.

Instead of either querying `http://checkip4.spdyn.de` or `http://checkip6.spdyn.de` I would advocate to query just `http://checkip.spdyn.de`. It returns the IPv4 or v6 address if the client has just one of them and the Ipv6 address if the client has both.