### PR TITLE
only enable fail2ban UFW filtering if UFW and fail2ban are both installed

### DIFF
--- a/bin/ncp/SECURITY/UFW.sh
+++ b/bin/ncp/SECURITY/UFW.sh
@@ -56,6 +56,13 @@ configure()
   ufw allow proto udp from 192.168.0.0/16
 
   echo "UFW enabled"
+
+  FAIL2BAN=$(dirname $0)/fail2ban.sh
+  if [ -f $FAIL2BAN ]; then
+    source $FAIL2BAN
+    enable_ufw_jail
+    service fail2ban restart
+  fi
 }
 
 # License

--- a/bin/ncp/SECURITY/fail2ban.sh
+++ b/bin/ncp/SECURITY/fail2ban.sh
@@ -160,11 +160,24 @@ filter = ufwban
 logpath = /var/log/ufw.log
 action = ufw
 EOF
+  enable_ufw_jail
   cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
   update-rc.d fail2ban defaults
   update-rc.d fail2ban enable
   service fail2ban restart
   echo "fail2ban enabled"
+}
+
+enable_ufw_jail()
+{
+  if is_active_app UFW; then
+    UFW_ENABLED=true
+  else
+    UFW_ENABLED=false
+  fi
+
+  # find "[ufwban]", then modify the next "enabled"
+  sed -i -e "/^\[ufwban\]/,/^enabled/ s/^enabled.*/enabled = $UFW_ENABLED/" /etc/fail2ban/jail.conf
 }
 
 # License


### PR DESCRIPTION
`enable_ufw_jail()` has been tested.

Full execution has *not* been tested. 

I'm unaware of a hook called if UFW is uninstalled.

See #913 for more discussion.