### PR TITLE
do not enable nextcloud app in update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -127,7 +127,7 @@ cp -r ncp-app /var/www/
 rm -rf /var/www/nextcloud/apps/nextcloudpi
 cp -r /var/www/ncp-app /var/www/nextcloud/apps/nextcloudpi
 chown -R www-data:     /var/www/nextcloud/apps/nextcloudpi
-ncc app:enable nextcloudpi
+
 
 [[ -f /.docker-image ]] && {
   # remove unwanted ncp-apps for the docker version


### PR DESCRIPTION
When creating new images `update.sh` gets called. At this point Nextcloud is not yet fully installed and `thus app:enable` fails. This PR just remove this one line.