### PR TITLE
Remove Expose Ports

### DIFF
--- a/docker/nextcloudpi/Dockerfile
+++ b/docker/nextcloudpi/Dockerfile
@@ -68,6 +68,3 @@ echo "${ncp_ver}" > /usr/local/etc/ncp-version
 COPY docker/nextcloudpi/000ncp /etc/services-enabled.d/
 COPY bin/ncp/CONFIG/nc-init.sh /
 COPY etc/ncp-config.d/nc-init.cfg /usr/local/etc/ncp-config.d/
-
-# 4443 - ncp-web
-EXPOSE 80 443 4443


### PR DESCRIPTION
If you start an docker image via `docker` or `docker-compose` all ports which are exposed through inside the Dockerfile are always opened! The user cannot disable it.

See `sudo docker ps` after starting nextcloudpi-docker: Ports 80, 443 and 4443 are always exposed on the host.

This even bypasses the **UFW** setup on the host system as docker directly modifies the ip-tables. There exist some issues on the Docker repo discussing this problem. But the easiest "workaround" is not to force-expose any ports.

Launching the Docker image normally or via docker-compose should not be affected. If the user has for example 

```
    ports:
     - 80:80
     - 443:443
     - 4443:4443
```

included in his compose file, he won't notice this change.

What do you think of this? Is there any reason I missed for exposing the ports via Dockerfile?

Greetings,
Daniel