### PR TITLE
prevent user query in ncp update

### DIFF
--- a/updates/1.16.0.sh
+++ b/updates/1.16.0.sh
@@ -27,7 +27,7 @@ apt-get install -y --no-install-recommends php-smbclient exfat-fuse exfat-utils
   # https://github.com/nextcloud/nextcloudpi/issues/938
   test -f /usr/bin/raspi-config && {
     apt-get update
-    apt-get install haveged
+    apt-get install -y haveged
     systemctl enable haveged.service
   }
 }


### PR DESCRIPTION
web interface was unable to conclude the update because it was asking for user input.
See https://github.com/nextcloud/nextcloudpi/issues/938