### PR TITLE
lamp.sh: install additionally needed php-imagick module for nextcloud 16

### DIFF
--- a/bin/ncp-dist-upgrade
+++ b/bin/ncp-dist-upgrade
@@ -47,6 +47,7 @@ set -e
 
 # update sources
 sed -i 's/stretch/buster/g' /etc/apt/sources.list
+sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/*
 rm -f /etc/apt/sources.list.d/php.list
 
 # install latest distro

--- a/lamp.sh
+++ b/lamp.sh
@@ -32,7 +32,7 @@ install()
 
     $APTINSTALL -t $RELEASE php${PHPVER} php${PHPVER}-curl php${PHPVER}-gd php${PHPVER}-fpm php${PHPVER}-cli php${PHPVER}-opcache \
                             php${PHPVER}-mbstring php${PHPVER}-xml php${PHPVER}-zip php${PHPVER}-fileinfo php${PHPVER}-ldap \
-                            php${PHPVER}-intl php${PHPVER}-bz2 php${PHPVER}-json
+                            php${PHPVER}-intl php${PHPVER}-bz2 php${PHPVER}-json php${PHPVER}-imagick
 
     mkdir -p /run/php
 

--- a/updates/1.16.0.sh
+++ b/updates/1.16.0.sh
@@ -15,6 +15,9 @@ apt-get install -y --no-install-recommends php-smbclient exfat-fuse exfat-utils
 # install lsb-release
 apt-get install -y --no-install-recommends lsb-release
 
+# missed some sources
+sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/* &>/dev/null
+
 # docker images only
 [[ -f /.docker-image ]] && {
 :


### PR DESCRIPTION
I found the file where the missing php module has to be installed to fix issue #965.
Nextcloud runs without complaining about missing php-imagick module.