### PR TITLE
custom code before/after auto-backup

### DIFF
--- a/bin/ncp/BACKUPS/nc-backup-auto.sh
+++ b/bin/ncp/BACKUPS/nc-backup-auto.sh
@@ -18,11 +18,13 @@ configure()
 
   cat > /usr/local/bin/ncp-backup-auto <<EOF
 #!/bin/bash
+[ -x /usr/local/bin/ncp-backup-auto-before ] && /usr/local/bin/ncp-backup-auto-before
 /usr/local/bin/ncc maintenance:mode --on
 /usr/local/bin/ncp-backup "$DESTDIR" "$INCLUDEDATA" "$COMPRESS" "$BACKUPLIMIT" || failed=true
 /usr/local/bin/ncc maintenance:mode --off
 [[ "\$failed" == "true" ]] && \
  /usr/local/bin/ncc notification:generate "$NOTIFYUSER" "Auto-backup failed" -l "Your automatic backup failed"
+[ -x /usr/local/bin/ncp-backup-auto-after ] && /usr/local/bin/ncp-backup-auto-after 
 EOF
   chmod +x /usr/local/bin/ncp-backup-auto
 

--- a/bin/ncp/BACKUPS/nc-backup-auto.sh
+++ b/bin/ncp/BACKUPS/nc-backup-auto.sh
@@ -24,7 +24,7 @@ configure()
 /usr/local/bin/ncc maintenance:mode --off
 [[ "\$failed" == "true" ]] && \
  /usr/local/bin/ncc notification:generate "$NOTIFYUSER" "Auto-backup failed" -l "Your automatic backup failed"
-[ -x /usr/local/bin/ncp-backup-auto-after ] && /usr/local/bin/ncp-backup-auto-after 
+[ -x /usr/local/bin/ncp-backup-auto-after ] && /usr/local/bin/ncp-backup-auto-after
 EOF
   chmod +x /usr/local/bin/ncp-backup-auto
 


### PR DESCRIPTION
One can create the scripts /usr/local/bin/ncp-backup-auto-before and /usr/local/bin/ncp-backup-auto-after, which are executed before/after the auto backup. This files are not affected by configuration changes or updates.
Signed-off-by: OlafBr <18134858+OlafBr@users.noreply.github.com>