### PR TITLE
added cp commands for folders 'ncp-app' and 'ncp-web'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,8 @@ mkdir -p /usr/local/etc/ncp-config.d/
 cp etc/ncp-config.d/nc-nextcloud.cfg /usr/local/etc/ncp-config.d/
 cp etc/library.sh /usr/local/etc/
 cp etc/ncp.cfg /usr/local/etc/
+cp -r ncp-app/ /var/www
+cp -r ncp-web/ /var/www
 
 install_app    lamp.sh
 install_app    bin/ncp/CONFIG/nc-nextcloud.sh


### PR DESCRIPTION
When installing with 'install.sh' script I had some issues due to missing folders 'ncp-app' & 'ncp-web' in '/var/www' folder. A copy command for both folders has been added.