### PR TITLE
Disable fail2ban UFW check for docker images

### DIFF
--- a/updates/1.17.0.sh
+++ b/updates/1.17.0.sh
@@ -15,8 +15,11 @@ sed -i "s/buster/$RELEASE/g" /etc/apt/sources.list.d/* &>/dev/null || true
 apt-get update
 apt-get install -y --no-install-recommends php${PHPVER}-gmp
 
-# fix fail2ban with UFW
+# fix fail2ban with UFW only for non docker images
+[[ -f /.docker-image ]] && {
 cat > /etc/systemd/system/fail2ban.service.d/touch-ufw-log.conf <<EOF
+}
+
 [Service]
 ExecStartPre=/bin/touch /var/log/ufw.log
 EOF


### PR DESCRIPTION
Fail2ban is not present on docker images and therefore prevent a successful update.