### PR TITLE
fixing file permission for redis config

### DIFF
--- a/bin/ncp-provisioning.sh
+++ b/bin/ncp-provisioning.sh
@@ -13,6 +13,7 @@ REDISPASS="$( grep "^requirepass" /etc/redis/redis.conf | cut -f2 -d' ' )"
   REDISPASS="$( openssl rand -base64 32 )"
   echo Provisioning Redis password
   sed -i -E "s|^requirepass .*|requirepass $REDISPASS|" /etc/redis/redis.conf
+  chown redis:redis /etc/redis/redis.conf
   [[ "$DOCKERBUILD" != 1 ]] && systemctl restart redis
 }
 

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -59,6 +59,7 @@ configure()
   local CURRENT_REDIS_MEM=$( grep "^maxmemory" "$CONF" | awk '{ print $2 }' )
   [[ "$REDISMEM" != "$CURRENT_REDIS_MEM" ]] && {
     sed -i "s|^maxmemory .*|maxmemory $REDISMEM|" "$CONF"
+    chown redis:redis $CONF
     service redis-server restart
   }
 }

--- a/docker/nextcloud/020nextcloud
+++ b/docker/nextcloud/020nextcloud
@@ -22,6 +22,7 @@ ln -s /data/nextcloud /var/www/nextcloud
 
 echo "Starting Redis"
 sed -i 's|^requirepass .*|requirepass default|' /etc/redis/redis.conf
+chown redis:redis /etc/redis/redis.conf
 mkdir -p /var/run/redis
 chown redis /var/run/redis
 sudo -u redis redis-server /etc/redis/redis.conf


### PR DESCRIPTION
I'm running ncp in docker.
This change fixed my problems with redis after updating.

Changing the redis.conf file leads to a permission change. This has to be reverted by the added command.

We also might have to change 
`bin/ncp/CONFIG/nc-nextcloud.sh`
since the file is adapted there as well.

fixes #1019 