### PR TITLE
Letsencrypt: support second domain

### DIFF
--- a/bin/ncp-provisioning.sh
+++ b/bin/ncp-provisioning.sh
@@ -13,6 +13,7 @@ REDISPASS="$( grep "^requirepass" /etc/redis/redis.conf | cut -f2 -d' ' )"
   REDISPASS="$( openssl rand -base64 32 )"
   echo Provisioning Redis password
   sed -i -E "s|^requirepass .*|requirepass $REDISPASS|" /etc/redis/redis.conf
+  chown redis:redis /etc/redis/redis.conf
   [[ "$DOCKERBUILD" != 1 ]] && systemctl restart redis
 }
 

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -59,6 +59,7 @@ configure()
   local CURRENT_REDIS_MEM=$( grep "^maxmemory" "$CONF" | awk '{ print $2 }' )
   [[ "$REDISMEM" != "$CURRENT_REDIS_MEM" ]] && {
     sed -i "s|^maxmemory .*|maxmemory $REDISMEM|" "$CONF"
+    chown redis:redis $CONF
     service redis-server restart
   }
 }

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -59,7 +59,7 @@ configure()
   local CURRENT_REDIS_MEM=$( grep "^maxmemory" "$CONF" | awk '{ print $2 }' )
   [[ "$REDISMEM" != "$CURRENT_REDIS_MEM" ]] && {
     sed -i "s|^maxmemory .*|maxmemory $REDISMEM|" "$CONF"
-    chown redis:redis $CONF
+    chown redis:redis "$CONF"
     service redis-server restart
   }
 }

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -103,7 +103,7 @@ EOF
     for dom in $DOMAIN $ADDITIONAL_DOMAIN; do
       [[ "$dom" != "" ]] && {
         ncc config:system:set trusted_domains $domain_index --value=$dom
-        ((domain_index=domain_index+1))
+        ((domain_index++))
       }
     done
     ncc config:system:set overwrite.cli.url --value=https://"$DOMAIN"/

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -99,7 +99,7 @@ EOF
     sed -i "s|SSLCertificateKeyFile.*|SSLCertificateKeyFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/privkey.pem|" $vhostcfg2
 
     # Configure Nextcloud
-    domain_index=12
+    local domain_index=12
     for dom in $DOMAIN $ADDITIONAL_DOMAIN; do
       [[ "$dom" != "" ]] && {
         ncc config:system:set trusted_domains $domain_index --value=$dom

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -54,7 +54,7 @@ configure()
     sed -i "/DocumentRoot/aServerName $DOMAIN" $vhostcfg
 
   # Do it
-  domain_string=""
+  local domain_string=""
   for domain in $DOMAIN $ADDITIONAL_DOMAIN; do
     [[ "$domain" != "" ]] && {
       [[ $domain_string == "" ]] && \

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -54,7 +54,15 @@ configure()
     sed -i "/DocumentRoot/aServerName $DOMAIN" $vhostcfg
 
   # Do it
-  $letsencrypt certonly -n --force-renew --no-self-upgrade --webroot -w $ncdir --hsts --agree-tos -m $EMAIL -d $DOMAIN && {
+  domain_string=""
+  for domain in $DOMAIN $ADDITIONAL_DOMAIN; do
+    [[ "$domain" != "" ]] && {
+      [[ $domain_string == "" ]] && \
+        domain_string+="${domain}" || \
+        domain_string+=",${domain}"
+    }
+  done
+  $letsencrypt certonly -n --force-renew --no-self-upgrade --webroot -w $ncdir --hsts --agree-tos -m $EMAIL -d $domain_string && {
 
     # Set up auto-renewal
     cat > /etc/cron.weekly/letsencrypt-ncp <<EOF
@@ -91,7 +99,13 @@ EOF
     sed -i "s|SSLCertificateKeyFile.*|SSLCertificateKeyFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/privkey.pem|" $vhostcfg2
 
     # Configure Nextcloud
-    ncc config:system:set trusted_domains 4 --value=$DOMAIN
+    domain_index=12
+    for dom in $DOMAIN $ADDITIONAL_DOMAIN; do
+      [[ "$dom" != "" ]] && {
+        ncc config:system:set trusted_domains $domain_index --value=$dom
+        ((domain_index=domain_index+1))
+      }
+    done
     ncc config:system:set overwrite.cli.url --value=https://"$DOMAIN"/
 
     # delayed in bg so it does not kill the connection, and we get AJAX response

--- a/docker/nextcloud/020nextcloud
+++ b/docker/nextcloud/020nextcloud
@@ -22,6 +22,7 @@ ln -s /data/nextcloud /var/www/nextcloud
 
 echo "Starting Redis"
 sed -i 's|^requirepass .*|requirepass default|' /etc/redis/redis.conf
+chown redis:redis /etc/redis/redis.conf
 mkdir -p /var/run/redis
 chown redis /var/run/redis
 sudo -u redis redis-server /etc/redis/redis.conf

--- a/etc/ncp-config.d/letsencrypt.cfg
+++ b/etc/ncp-config.d/letsencrypt.cfg
@@ -15,7 +15,7 @@
     {
       "id": "ADDITIONAL_DOMAIN",
       "name": "Additional domain",
-      "value": "cloud.ownyourbits.com",
+      "value": "",
       "suggest": "cloud.ownyourbits.com"
     },
     {

--- a/etc/ncp-config.d/letsencrypt.cfg
+++ b/etc/ncp-config.d/letsencrypt.cfg
@@ -13,6 +13,12 @@
       "suggest": "mycloud.ownyourbits.com"
     },
     {
+      "id": "ADDITIONAL_DOMAIN",
+      "name": "Additional domain",
+      "value": "cloud.ownyourbits.com",
+      "suggest": "cloud.ownyourbits.com"
+    },
+    {
       "id": "EMAIL",
       "name": "Email",
       "value": "mycloud@ownyourbits.com",


### PR DESCRIPTION
The ncp letsencrypt app now allows a second domain to be specified.
Fix: #837