### PR TITLE
Extend the ssh configuration check by calling the echo command if the…

### DIFF
--- a/bin/ncp/BACKUPS/nc-rsync-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-auto.sh
@@ -28,10 +28,12 @@ configure()
     return 1;
   }
 
+  # Check if the ssh access is properly configured. For this purpose the command : or echo is called remotely.
+  # If one of the commands works, the test is successful.
   [[ "$DESTINATION" =~ : ]] && {
     local NET="$( sed 's|:.*||' <<<"$DESTINATION" )"
     local SSH=( ssh -o "BatchMode=yes" -p "$PORTNUMBER" "$NET" )
-    ${SSH[@]} : || { echo "SSH non-interactive not properly configured"; return 1; }
+    ${SSH[@]} : || ${SSH[@]} echo || { echo "SSH non-interactive not properly configured"; return 1; }
   }
 
   echo "0  5  */${SYNCDAYS}  *  *  root  /usr/bin/rsync -ax -e \"ssh -p $PORTNUMBER\" --delete \"$DATADIR\" \"$DESTINATION\"" > /etc/cron.d/ncp-rsync-auto


### PR DESCRIPTION
Fix for #1027 

To check the ssh configuration it is tested if the : command can be executed remotely. Rsync.net doesn't allow the : command, so I suggest to additionally check if the echo command can be executed remotely.

Please let me know if there's anything I can improve (this is my first contribution to an open source project).