### PR TITLE
multi factor authentication for ssh

### DIFF
--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -174,13 +174,14 @@ is_active() {
 
 configure() {
 
-  local active enable_totp_and_pw enable_pubkey_and_pw enable_pubkey_only enable_pw_only reset_totp_secret
+  local active enable_totp_and_pw enable_pubkey_and_pw enable_pubkey_only enable_pw_only reset_totp_secret ssh_pubkey
   enable_totp_and_pw="$ENABLE_TOTP_AND_PASSWORD"
   enable_pubkey_and_pw="$ENABLE_PUBLIC_KEY_AND_PASSWORD"
   enable_pubkey_only="$ENABLE_PUBLIC_KEY_ONLY"
   enable_pw_only="$ENABLE_PASSWORD_ONLY"
   reset_totp_secret="$RESET_TOTP_SECRET"
   active="$ACTIVE"
+  ssh_pubkey="$(unescape "$SSH_PUBLIC_KEY")"
 
   trap 'restore' HUP INT QUIT PIPE TERM
 
@@ -234,10 +235,10 @@ configure() {
   }
 
   # Setup SSH public key if provided
-  if [[ -n "$SSH_PUBLIC_KEY" ]]
+  if [[ -n "$ssh_pubkey" ]]
   then
     echo "Setting up SSH public key..."
-    echo "$SSH_PUBLIC_KEY" > "${SSH_USER_HOME}/.ssh/authorized_keys"
+    echo "$ssh_pubkey" > "${SSH_USER_HOME}/.ssh/authorized_keys"
     chown "${SSH_USER}:" "${SSH_USER_HOME}/.ssh/authorized_keys"
   fi
 

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -136,7 +136,12 @@ setup_totp_secret() {
 
   [[ "$reset_totp_secret" == "yes" ]] \
   && [[ -f "$ssh_user_home/.google_authenticator" ]] \
-  && su "$ssh_user" -c "rm '${ssh_user_home}/.google_authenticator'"
+  && {
+    echo "Deleting google authenticator configuration"
+    su "$ssh_user" -c "chmod u+w '${ssh_user_home}/.google_authenticator'"
+    su "$ssh_user" -c "rm '${ssh_user_home}/.google_authenticator'"
+  }
+
 
   if [[ "$enable_totp_and_pw" == "yes" ]] && [[ ! -f "${ssh_user_home}/.google_authenticator" ]]
   then

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -228,12 +228,12 @@ configure() {
   SSH_USER="$(jq -r '.params[] | select(.id == "USER") | .value' < /usr/local/etc/ncp-config.d/SSH.cfg)"
   SSH_USER_HOME="$(sudo -Hu "$SSH_USER" bash -c 'echo "$HOME"')"
 
-  if [[ -n "$SSH_USER" ]] && id -u "$SSH_USER" > /dev/null
-  then
+  [[ -n "$SSH_USER" ]] || id -u "$SSH_USER" > /dev/null || {
     echo "Setup incomplete. Please configure SSH via the ncp app and rerun."
     return 1
-  fi
+  }
 
+  # Setup SSH public key if provided
   if [[ -n "$SSH_PUBLIC_KEY" ]]
   then
     echo "Setting up SSH public key..."
@@ -242,5 +242,7 @@ configure() {
   fi
 
   setup_totp_secret "$SSH_USER" "$SSH_USER_HOME"
+
+  echo "Done."
 
 }

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -141,6 +141,11 @@ restore() {
 
 ################################################################
 
+cleanup() {
+  restore
+  [[ -d "${PAMD_BACKUP_PATH}" ]] && rm -r "${PAMD_BACKUP_PATH}"
+}
+
 install() {
   apt install libpam-google-authenticator
 }

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -147,7 +147,7 @@ cleanup() {
 }
 
 install() {
-  apt install libpam-google-authenticator
+  apt install -y libpam-google-authenticator
 }
 
 is_active() {

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -24,7 +24,7 @@ patch_pam_ssh_config() {
     if [[ -f "${PAMD_BACKUP_PATH}/sshd" ]]; then
       echo "Restoring original configuration for '${PAMD_PATH}/sshd'..."
       mv "${PAMD_BACKUP_PATH}/sshd" "${PAMD_PATH}/sshd" || return 1
-      rm "${PAMD_PATH}/sshd-mfa"
+      [[ -f "${PAMD_PATH}/sshd-mfa" ]] && rm "${PAMD_PATH}/sshd-mfa"
       return 0
     else
       echo "ERROR: Could not restore '${PAMD_PATH}/sshd' from backup '${PAMD_BACKUP_PATH}/sshd' (not found)!"
@@ -110,7 +110,7 @@ patch_sshd_config() {
 PasswordAuthentication yes
 PubkeyAuthentication yes
 ChallengeResponseAuthentication yes
-UsePAM yes
+UsePAM $enable_totp_and_pw
 AuthenticationMethods $auth_method
 
 EOF
@@ -120,8 +120,8 @@ EOF
 setup_configuration() {
   local auth_method=""
 
-  [[ "$enable_pubkey_only" ]] && auth_method="publickey"
-  [[ "$enable_pw_only" ]] && auth_method="${auth_method} password"
+  [[ "$enable_pubkey_only" == "yes" ]] && auth_method="publickey"
+  [[ "$enable_pw_only" == "yes" ]] && auth_method="${auth_method} password"
 
   [[ "$enable_totp_and_pw" == "yes" ]] && auth_method="keyboard-interactive"
   [[ "$enable_pubkey_and_pw" == "yes" ]] && auth_method="${auth_method} publickey,password"

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+# Authentication Options:
+# =======================
+# * Password
+# * Pubkey
+# * TOTP + Password
+# (* TOTP + Pubkey + Password) not yet supported
+# * TOTP + Password / TOTP + Pubkey
+
+PAMD_PATH="./test/etc/pam.d"
+PAMD_BACKUP_PATH="./test/etc/pam.backup"
+SSHD_CONFIG_PATH="./test/etc/ssh/sshd_config"
+
+
+# Configure pam.d/sshd config
+# ======================
+
+patch_pam_ssh_config() {
+  local cfg
+
+  if [[ "$1" == "--reset" ]]; then
+    if [[ -f "${PAMD_BACKUP_PATH}/sshd" ]]; then
+      echo "Restoring original configuration for '${PAMD_PATH}/sshd'..."
+      mv "${PAMD_BACKUP_PATH}/sshd" "${PAMD_PATH}/sshd" || return 1
+      rm "${PAMD_PATH}/sshd-mfa"
+      return 0
+    else
+      echo "ERROR: Could not restore '${PAMD_PATH}/sshd' from backup '${PAMD_BACKUP_PATH}/sshd' (not found)!"
+      return 1
+    fi
+  fi
+
+  mkdir -p "$PAMD_BACKUP_PATH"
+  [[ -f "${PAMD_BACKUP_PATH}/sshd" ]] || {
+    echo "Backing up '${PAMD_PATH}/sshd'..."
+    cp "${PAMD_PATH}/sshd" "${PAMD_BACKUP_PATH}/sshd"
+  } || {
+    echo "Error creating backup. '${PAMD_PATH}/sshd will remain unchanged!"
+    return 1
+  }
+
+  echo "Writing pam configuration..."
+  echo "" > "${PAMD_PATH}/sshd-mfa" || return 1
+
+  if [[ "$ENABLE_TOTP_AND_PASSWORD" == "true" ]]; then
+    echo "auth required pam_google_authenticator.so nullok" >> "${PAMD_PATH}/sshd-mfa"
+  fi
+  echo "@include common-auth" >> "${PAMD_PATH}/sshd-mfa"
+
+  sed -i 's/@include.*common-auth/@include sshd-mfa/g' "${PAMD_PATH}/sshd" || return 1
+
+
+}
+
+# Configure sshd_config
+# =====================
+
+#sshd_authentication_options=("password" "publickey" "publickey,password" "keyboard-interactive"
+#  "keyboard-interactive,publickey" "keyboard-interactive,publickey keyboard-interactive,password")
+patch_sshd_config() {
+  local cfg
+  local auth_method="${1?}"
+
+  if [[ "$auth_method" == "--reset" ]]
+  then
+    if [[ -f "${SSHD_CONFIG_PATH}.backup" ]]
+    then
+      echo "Restoring '${SSHD_CONFIG_PATH}' from '${SSHD_CONFIG_PATH}.backup'..."
+      mv "${SSHD_CONFIG_PATH}.backup" "${SSHD_CONFIG_PATH}" || return 1
+      return 0
+    else
+      echo "ERROR: Could not restore '${SSHD_CONFIG_PATH}' from '${SSHD_CONFIG_PATH}.backup' (not found)!"
+      return 1
+    fi
+  fi
+
+  # backup sshd_config
+  mkdir -p /etc/pam.backup
+  [[ -f "${SSHD_CONFIG_PATH}.backup" ]] || {
+    echo "Backing up '${SSHD_CONFIG_PATH}'..."
+    cp "$SSHD_CONFIG_PATH" "${SSHD_CONFIG_PATH}.backup"
+  } || {
+    echo "Error creating backup. '${PAMD_PATH}/sshd will remain unchanged!"
+    return 1
+  }
+
+  # get sshd_config without google_authenticator
+  cfg="$(
+    grep -v -e "AuthenticationMethods" "${SSHD_CONFIG_PATH}.backup" |
+      grep -v -e "ChallengeResponseAuthentication" |
+      grep -v -e "PubkeyAuthentication" |
+      grep -v -e "PasswordAuthentication" |
+      grep -v -e "UsePAM"
+  )"
+
+  echo "Writing sshd configuration..."
+  echo "$cfg" > "$SSHD_CONFIG_PATH" || return 1
+  cat << EOF >> "$SSHD_CONFIG_PATH"
+
+###################################
+
+PasswordAuthentication yes
+PubkeyAuthentication yes
+ChallengeResponseAuthentication yes
+UsePAM yes
+AuthenticationMethods $auth_method
+
+EOF
+
+}
+
+setup_configuration() {
+  local auth_method=""
+
+  [[ "$enable_pubkey_only" ]] && auth_method="publickey"
+  [[ "$enable_password_only" ]] && auth_method="${auth_method} password"
+
+  [[ "$ENABLE_TOTP_AND_PASSWORD" == "yes" ]] && auth_method="keyboard-interactive"
+  [[ "$ENABLE_PUBLIC_KEY_AND_PASSWORD" == "yes" ]] && auth_method="${auth_method} publickey,password"
+
+  patch_pam_ssh_config || return 2
+  patch_sshd_config "$auth_method" || return 1
+}
+
+restore() {
+  local ret=0
+  patch_pam_ssh_config --reset
+  ret=$((ret + $?))
+  patch_sshd_config --reset
+  ret=$((ret + $?))
+  return $ret
+}
+
+################################################################
+
+install() {
+  apt install libpam-google-authenticator
+}
+
+is_active() {
+  [[ ! -f "${SSHD_CONFIG_PATH}" ]] \
+  || [[ ! -f "${PAMD_PATH}/sshd" ]] \
+  || grep -q -e "AuthenticationMethods.*keyboard-interactive" -e "AuthenticationMethods.*publickey" "${SSHD_CONFIG_PATH}" \
+  || grep -q -e "sshd-mfa" "${PAMD_PATH}/sshd"
+}
+
+configure() {
+
+  local active enable_totp_and_pw enable_pubkey_and_pw enable_pubkey_only enable_pw_only reset_totp_secret
+  enable_totp_and_pw="$ENABLE_TOTP_AND_PASSWORD"
+  enable_pubkey_and_pw="$ENABLE_PUBLIC_KEY_AND_PASSWORD"
+  enable_pubkey_only="$ENABLE_PUBLIC_KEY_ONLY"
+  enable_pw_only="$ENABLE_PASSWORD_ONLY"
+  reset_totp_secret="$RESET_TOTP_SECRET"
+  active="$ACTIVE"
+
+  trap 'restore' HUP INT QUIT PIPE TERM
+
+  if [[ "$active" == "yes" ]] && [[ "$enable_totp_and_pw" != "yes" ]] \
+  && [[ "$enable_pubkey_and_pw" != "yes" ]] && [[ "$enable_pubkey_only" != "yes" ]]
+  then
+    [[ $enable_pw_only ]] \
+    || echo "WARNING: No authentication method has been enabled. Enabling default authentication (password only)..."
+    active="no"
+  fi
+
+  if [[ "$active" != "yes" ]]
+  then
+    ret=0
+    is_active && { restore || ret=$?; }
+    systemctl is-enabled ssh -q && systemctl restart ssh
+    return $ret
+  else
+#    ENABLE_TOTP_AND_PASSWORD=""
+#    ENABLE_PUBLIC_KEY_AND_PASSWORD=""
+#    ENABLE_PUBLIC_KEY_ONLY=""
+
+    if [[ "$enable_totp_and_pw" == "yes" ]] || [[ "$enable_pubkey_and_pw" ]]
+    then
+      if [[ "$ENABLE_PUBLIC_KEY_ONLY" == "yes" ]]
+      then
+        echo "At least one multifactor authentication method has been enabled. Therefore, weaker authentication methods will be disabled automatically."
+        echo "Disabling 'public key only' authentication"
+        enable_pubkey_only=no
+      fi
+    fi
+  fi
+
+  echo "Setting up configuration files..."
+  setup_configuration || {
+    ret=$?
+    restore
+    return $ret
+  }
+
+  echo "Restarting ssh service..."
+  systemctl is-enabled ssh -q && systemctl restart ssh
+
+  # TODO: Should we rather provider an input field for the SSH user (what happens if it is changed in the ssh config)?
+  SSH_USER="$(jq '.params[] | select(.id == "USER") | .value' < /etc/ncp-config.d/SSH.cfg)"
+
+  [[ "$reset_totp_secret" == "yes" ]] \
+  && [[ -f "~$SSH_USER/.google_authenticator" ]] \
+  && su "$SSH_USER" -c "rm '~$SSH_USER/.google_authenticator'"
+
+  if [[ "$enable_totp_and_pw" ]] && [[ ! -f "~$SSH_USER/.google_authenticator" ]]
+  then
+    echo "We will now generate TOTP a client secret for your ssh user ('$SSH_USER')."
+    echo "Please store the following information in a safe place. Use your secret key or scan the QR code (terminal only) to setup your authenticator app."
+    echo ""
+    su "$SSH_USER" -c "google-authenticator -tdf -w 1 --no-rate-limit"
+  fi
+
+}

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -148,9 +148,7 @@ setup_totp_secret() {
     echo "We will now generate TOTP a client secret for your ssh user ('$ssh_user')."
     echo "Please store the following information in a safe place. Use your secret key or scan the QR code (terminal only) to setup your authenticator app."
     echo ""
-    echo "<pre style=\"font-family: mono;\">"
-    su "$ssh_user" -c "google-authenticator -tdf -Q UTF8 -w 1 --no-rate-limit"
-    echo "</pre>"
+    su "$ssh_user" -c "google-authenticator -tdf -w 1 --no-rate-limit"
   fi
 }
 

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -208,7 +208,7 @@ configure() {
   systemctl is-enabled ssh -q && systemctl restart ssh
 
   # TODO: Should we rather provider an input field for the SSH user (what happens if it is changed in the ssh config)?
-  SSH_USER="$(jq '.params[] | select(.id == "USER") | .value' < /etc/ncp-config.d/SSH.cfg)"
+  SSH_USER="$(jq -r '.params[] | select(.id == "USER") | .value' < /usr/local/etc/ncp-config.d/SSH.cfg)"
 
   [[ "$reset_totp_secret" == "yes" ]] \
   && [[ -f "~$SSH_USER/.google_authenticator" ]] \

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -151,9 +151,7 @@ install() {
 }
 
 is_active() {
-  [[ ! -f "${SSHD_CONFIG_PATH}" ]] \
-  || [[ ! -f "${PAMD_PATH}/sshd" ]] \
-  || grep -q -e "AuthenticationMethods.*keyboard-interactive" -e "AuthenticationMethods.*publickey" "${SSHD_CONFIG_PATH}" \
+  grep -q -e "AuthenticationMethods.*keyboard-interactive" -e "AuthenticationMethods.*publickey" "${SSHD_CONFIG_PATH}" \
   || grep -q -e "sshd-mfa" "${PAMD_PATH}/sshd"
 }
 

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -194,7 +194,7 @@ is_active() {
 
 configure() {
 
-  local active enable_totp_and_pw enable_pubkey_and_pw enable_pubkey_only enable_pw_only reset_totp_secret ssh_pubkey
+  local active enable_totp_and_pw enable_pubkey_and_pw enable_pubkey_only enable_pw_only reset_totp_secret ssh_pubkeys
   enable_totp_and_pw="$ENABLE_TOTP_AND_PASSWORD"
   enable_pubkey_and_pw="$ENABLE_PUBLIC_KEY_AND_PASSWORD"
   enable_pubkey_only="$ENABLE_PUBLIC_KEY_ONLY"

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -148,7 +148,9 @@ setup_totp_secret() {
     echo "We will now generate TOTP a client secret for your ssh user ('$ssh_user')."
     echo "Please store the following information in a safe place. Use your secret key or scan the QR code (terminal only) to setup your authenticator app."
     echo ""
-    su "$ssh_user" -c "google-authenticator -tdf -w 1 --no-rate-limit"
+    echo "<pre style=\"font-family: mono;\">"
+    su "$ssh_user" -c "google-authenticator -tdf -Q UTF8 -w 1 --no-rate-limit"
+    echo "</pre>"
   fi
 }
 

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -260,12 +260,16 @@ configure() {
   echo "Restarting ssh service..."
   systemctl is-enabled ssh -q && systemctl restart ssh
 
-  # Setup SSH public key if provided
-  if [[ -n "$ssh_pubkey" ]]
+  # Setup SSH public key
+  if [[ -n "$SSH_PUBLIC_KEY" ]]
   then
     echo "Setting up SSH public key..."
     echo "$ssh_pubkey" > "${SSH_USER_HOME}/.ssh/authorized_keys"
     chown "${SSH_USER}:" "${SSH_USER_HOME}/.ssh/authorized_keys"
+  elif [[ -f "${SSH_USER_HOME}/.ssh/authorized_keys" ]]
+  then
+    echo "Removing authorized ssh public key"
+    rm "${SSH_USER_HOME}/.ssh/authorized_keys"
   fi
 
   setup_totp_secret "$SSH_USER" "$SSH_USER_HOME"

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -206,8 +206,6 @@ configure() {
                "$(unescape "$SSH_PUBLIC_KEY_3")" \
                "$(unescape "$SSH_PUBLIC_KEY_4")" \
                "$(unescape "$SSH_PUBLIC_KEY_5")")
-  echo "SSH PUBKEYS:"
-  echo "${ssh_pubkeys[*]}"
 
   trap 'restore' HUP INT QUIT PIPE TERM
 

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -146,7 +146,7 @@ setup_totp_secret() {
   if [[ "$enable_totp_and_pw" == "yes" ]] && [[ ! -f "${ssh_user_home}/.google_authenticator" ]]
   then
     echo "We will now generate TOTP a client secret for your ssh user ('$ssh_user')."
-    echo "Please store the following information in a safe place. Use your secret key or scan the QR code (terminal only) to setup your authenticator app."
+    echo "Please store the following information in a safe place. Use your secret key to setup your authenticator app."
     echo ""
     su "$ssh_user" -c "google-authenticator -tdf -w 1 --no-rate-limit"
   fi

--- a/bin/ncp/SECURITY/multi-factor-authentication.sh
+++ b/bin/ncp/SECURITY/multi-factor-authentication.sh
@@ -201,7 +201,13 @@ configure() {
   enable_pw_only="$ENABLE_PASSWORD_ONLY"
   reset_totp_secret="$RESET_TOTP_SECRET"
   active="yes"
-  ssh_pubkey="$(unescape "$SSH_PUBLIC_KEY")"
+  ssh_pubkeys=("$(unescape "$SSH_PUBLIC_KEY_1")" \
+               "$(unescape "$SSH_PUBLIC_KEY_2")" \
+               "$(unescape "$SSH_PUBLIC_KEY_3")" \
+               "$(unescape "$SSH_PUBLIC_KEY_4")" \
+               "$(unescape "$SSH_PUBLIC_KEY_5")")
+  echo "SSH PUBKEYS:"
+  echo "${ssh_pubkeys[*]}"
 
   trap 'restore' HUP INT QUIT PIPE TERM
 
@@ -266,10 +272,13 @@ configure() {
   systemctl is-enabled ssh -q && systemctl restart ssh
 
   # Setup SSH public key
-  if [[ -n "$SSH_PUBLIC_KEY" ]]
+  if [[ -n "${ssh_pubkeys[*]}" ]]
   then
     echo "Setting up SSH public key..."
-    echo "$ssh_pubkey" > "${SSH_USER_HOME}/.ssh/authorized_keys"
+    local IFS_BK="$IFS"
+    IFS=$'\n'
+    echo "${ssh_pubkeys[*]}" > "${SSH_USER_HOME}/.ssh/authorized_keys"
+    IFS="$IFS_BK"
     chown "${SSH_USER}:" "${SSH_USER_HOME}/.ssh/authorized_keys"
   elif [[ -f "${SSH_USER_HOME}/.ssh/authorized_keys" ]]
   then

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -73,8 +73,13 @@ function configure_app()
       $DIALOG_OK)
         while read val; do local ret_vals+=("$val"); done <<<"$value"
 
+        local allow_unsafe
+
         for (( i = 0 ; i < len ; i++ )); do
           # check for invalid characters
+          # check if unsafe characters (spaces) are allowed (will return 'null' if key not found)
+          allow_unsafe="$(jq -r .params[$i].allow_unsafe <<<"$cfg")"
+          [[ "${allow_unsafe}" == 'true' ]] && ret_vals[$i]="${ret_vals[$i]// /%SPACE%}"
           grep -q '[\\&#;'"'"'`|*?~<>^"()[{}$&[:space:]]' <<< "${ret_vals[$i]}" && { echo "Invalid characters in field ${vars[$i]}"; return 1; }
 
           cfg="$(jq ".params[$i].value = \"${ret_vals[$i]}\"" <<<"$cfg")"

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -278,6 +278,12 @@ function check_distro()
   return 1
 }
 
+function unescape()
+{
+  local str="${1?}"
+  echo "${str//"%SPACE%"/" "}"
+}
+
 function apt_install()
 {
   apt-get update

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -31,7 +31,7 @@
       "type": "bool"
     },
     {
-      "id": "RESET_TOTP SECRET",
+      "id": "RESET_TOTP_SECRET",
       "name": "reset-TOTP-secret",
       "value": "no",
       "type": "bool"

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -1,9 +1,9 @@
 {
-  "id": "MFA",
+  "id": "multi-factor-authentication",
   "name": "Activate multi factory authentication for SSH login",
   "title": "Multi-Factor-Authentication",
   "description": "Choose among different (single and multi factor) authentication methods for SSH login.",
-  "info": "The default method (e.g. when this app is disabled) is 'password only'. Please not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods",
+  "info": "The default method (e.g. when this app is disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods",
   "infotitle": "MFA notes",
   "params": [
     {
@@ -14,31 +14,31 @@
     },
     {
       "id": "ENABLE_PASSWORD_ONLY",
-      "name": "enable password only authentication",
+      "name": "enable-password-only-authentication",
       "value": "yes",
       "type": "bool"
     },
     {
       "id": "ENABLE_PUBLIC_KEY_ONLY",
-      "name": "enable public key only authentication",
+      "name": "enable-public-key-only-authentication",
       "value": "no",
       "type": "bool"
     },
     {
       "id": "ENABLE_PUBLIC_KEY_AND_PASSWORD",
-      "name": "enable public key + password authentication (MFA)",
+      "name": "enable-public-key-plus-password-authentication",
       "value": "no",
       "type": "bool"
     },
     {
       "id": "ENABLE_TOTP_AND_PASSWORD",
-      "name": "enable time-based one time password (TOTP) + password (MFA)",
+      "name": "enable-time-based-one-time-password-plus-password",
       "value": "no",
       "type": "bool"
     },
     {
-      "id": "RESET_TOTP CLIENT SECRET",
-      "name": "reset the TOTP client secret when applying changes",
+      "id": "RESET_TOTP SECRET",
+      "name": "reset-the-TOTP-client-secret-when-applying-changes",
       "value": "no",
       "type": "bool"
     }

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -2,8 +2,8 @@
   "id": "multi-factor-authentication",
   "name": "Activate multi factory authentication for SSH login",
   "title": "Multi-Factor-Authentication",
-  "description": "Choose among different (single and multi factor) authentication methods for SSH login.",
-  "info": "The default method (i.e. this app being disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods.\nThe TOTP authentication requires a compatible app to be used, e.g. FreeOTP, Keepass2Android, Google Authenticator or Authy.\nIf you enable multiple options, they will act as alternatives.",
+  "description": "Choose the authentication method for SSH login.",
+  "info": "The default method is 'password only'.\nPlease note that single factor authentication methods can not be enabled at the same time as multi factor authentication methods.\nThe TOTP authentication requires a compatible app to be used, e.g. FreeOTP, Keepass2Android, Google Authenticator or Authy.\nIf you enable multiple options, they will act as alternatives.",
   "infotitle": "MFA notes",
   "params": [
     {

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -14,33 +14,39 @@
     },
     {
       "id": "ENABLE_PASSWORD_ONLY",
-      "name": "enable-password-only-authentication",
+      "name": "enable-password-only",
       "value": "yes",
       "type": "bool"
     },
     {
       "id": "ENABLE_PUBLIC_KEY_ONLY",
-      "name": "enable-public-key-only-authentication",
+      "name": "enable-public-key-only",
       "value": "no",
       "type": "bool"
     },
     {
       "id": "ENABLE_PUBLIC_KEY_AND_PASSWORD",
-      "name": "enable-public-key-plus-password-authentication",
+      "name": "enable-public-key-plus-password",
       "value": "no",
       "type": "bool"
     },
     {
       "id": "ENABLE_TOTP_AND_PASSWORD",
-      "name": "enable-time-based-one-time-password-plus-password",
+      "name": "enable-TOTP-plus-password",
       "value": "no",
       "type": "bool"
     },
     {
       "id": "RESET_TOTP SECRET",
-      "name": "reset-the-TOTP-client-secret-when-applying-changes",
+      "name": "reset-TOTP-secret",
       "value": "no",
       "type": "bool"
+    },
+    {
+      "id": "SSH_PUBLIC_KEY",
+      "name": "SSH Public Key",
+      "value": "",
+      "suggest": "Paste your public key here"
     }
   ]
 }

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -3,7 +3,7 @@
   "name": "Activate multi factory authentication for SSH login",
   "title": "Multi-Factor-Authentication",
   "description": "Choose among different (single and multi factor) authentication methods for SSH login.",
-  "info": "The default method (e.g. when this app is disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods",
+  "info": "The default method (i.e. this app being disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods.\nThe TOTP authentication requires a compatible app to be used, e.g. FreeOTP, Google Authenticator or Authy.\nIf you enable multiple options, they will act as alternatives.",
   "infotitle": "MFA notes",
   "params": [
     {

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -3,7 +3,7 @@
   "name": "Activate multi factory authentication for SSH login",
   "title": "Multi-Factor-Authentication",
   "description": "Choose among different (single and multi factor) authentication methods for SSH login.",
-  "info": "The default method (i.e. this app being disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods.\nThe TOTP authentication requires a compatible app to be used, e.g. FreeOTP, Google Authenticator or Authy.\nIf you enable multiple options, they will act as alternatives.",
+  "info": "The default method (i.e. this app being disabled) is 'password only'.\nPlease not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods.\nThe TOTP authentication requires a compatible app to be used, e.g. FreeOTP, Keepass2Android, Google Authenticator or Authy.\nIf you enable multiple options, they will act as alternatives.",
   "infotitle": "MFA notes",
   "params": [
     {

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -37,11 +37,39 @@
       "type": "bool"
     },
     {
-      "id": "SSH_PUBLIC_KEY",
-      "name": "SSH Public Key",
+      "id": "SSH_PUBLIC_KEY_1",
+      "name": "SSH Public Key 1",
       "value": "",
       "suggest": "Paste your public key here",
       "allow_unsafe": "true"
+    },
+    {
+    "id": "SSH_PUBLIC_KEY_2",
+    "name": "SSH Public Key 2",
+    "value": "",
+    "suggest": "Paste your public key here",
+    "allow_unsafe": "true"
+    },
+    {
+    "id": "SSH_PUBLIC_KEY_3",
+    "name": "SSH Public Key 3",
+    "value": "",
+    "suggest": "Paste your public key here",
+    "allow_unsafe": "true"
+    },
+    {
+    "id": "SSH_PUBLIC_KEY_4",
+    "name": "SSH Public Key 4",
+    "value": "",
+    "suggest": "Paste your public key here",
+    "allow_unsafe": "true"
+    },
+    {
+    "id": "SSH_PUBLIC_KEY_5",
+    "name": "SSH Public Key 5",
+    "value": "",
+    "suggest": "Paste your public key here",
+    "allow_unsafe": "true"
     }
   ]
 }

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -7,12 +7,6 @@
   "infotitle": "MFA notes",
   "params": [
     {
-      "id": "ACTIVE",
-      "name": "Active",
-      "value": "no",
-      "type": "bool"
-    },
-    {
       "id": "ENABLE_PASSWORD_ONLY",
       "name": "enable-password-only",
       "value": "yes",

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -1,0 +1,46 @@
+{
+  "id": "MFA",
+  "name": "Activate multi factory authentication for SSH login",
+  "title": "Multi-Factor-Authentication",
+  "description": "Choose among different (single and multi factor) authentication methods for SSH login.",
+  "info": "The default method (e.g. when this app is disabled) is 'password only'. Please not that single factor authentication methods can not be enabled at the same time as multi factor authentication methods",
+  "infotitle": "MFA notes",
+  "params": [
+    {
+      "id": "ACTIVE",
+      "name": "Active",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "ENABLE_PASSWORD_ONLY",
+      "name": "enable password only authentication",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
+      "id": "ENABLE_PUBLIC_KEY_ONLY",
+      "name": "enable public key only authentication",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "ENABLE_PUBLIC_KEY_AND_PASSWORD",
+      "name": "enable public key + password authentication (MFA)",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "ENABLE_TOTP_AND_PASSWORD",
+      "name": "enable time-based one time password (TOTP) + password (MFA)",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "RESET_TOTP CLIENT SECRET",
+      "name": "reset the TOTP client secret when applying changes",
+      "value": "no",
+      "type": "bool"
+    }
+  ]
+}

--- a/etc/ncp-config.d/multi-factor-authentication.cfg
+++ b/etc/ncp-config.d/multi-factor-authentication.cfg
@@ -46,7 +46,8 @@
       "id": "SSH_PUBLIC_KEY",
       "name": "SSH Public Key",
       "value": "",
-      "suggest": "Paste your public key here"
+      "suggest": "Paste your public key here",
+      "allow_unsafe": "true"
     }
   ]
 }

--- a/ncp-web/elements.php
+++ b/ncp-web/elements.php
@@ -24,6 +24,8 @@ HTML;
     $ret .= "<td><label for=\"$ncp_app-$param[id]\">$param[name]</label></td>";
 
     $value = $param['value'];
+    if (array_key_exists('allow_unsafe', $param) && $param['allow_unsafe'] == "true")
+        $value = str_replace("%SPACE%", " ", $value);
     if ( $value == '_')
       $value = '';
 

--- a/ncp-web/ncp-launcher.php
+++ b/ncp-web/ncp-launcher.php
@@ -66,6 +66,8 @@ if ( $_POST['action'] == "launch" && $_POST['config'] )
 
       // sanitize
       $val = trim(escapeshellarg($new_params[$id]),"'");
+      if (array_key_exists('allow_unsafe', $cfg['params'][$index]) && $cfg['params'][$index]['allow_unsafe'] == "true")
+        $val = str_replace(" ", "%SPACE%", $val);
       preg_match( '/[\'" ]/' , $val , $matches )
         and exit( '{ "output": "Invalid parameters" , "token": "' . getCSRFToken() . '" }' );
 


### PR DESCRIPTION
As proposed in #1035 I implemented an ncp app to manage multi (and single) factor authentication methods. Currently supported are:

- password only (default)
- public key authentication
- public key + password
- TOTP (google-authenticator based) + password

If multiple options are enabled, they will act as alternatives. However, if at least one mfa method is enabled, all single factor methods will be disabled automatically. 
Also, it is unfortunately impossible to use totp (or any PAM based) authentication methods with non-PAM password authentication. That makes some combinations invalid, e.g. having pubkey+pw and totp+pw both enabled.

Functionality wise I'm satisfied with the current state of the ncp app now. The only missing things that I'm aware of are documentation and localization at this point.

**TODO:**

- [x] Implement provision of ssh public key
- [x] Prevent invalid/broken combinations of parameters/authentication methods
- [x] Fix terminal version (when run via ncp-config)
- [x] ~Provide QR-Code in web interface (?)~
- [x] ~Add localization~
- [x] Test with debian buster

![image](https://user-images.githubusercontent.com/6317548/70864351-4ba2e480-1f51-11ea-900d-4633b75a3e93.png)

![image](https://user-images.githubusercontent.com/6317548/70842489-9a069500-1e24-11ea-84ee-52d47947623e.png)

   