### PR TITLE
Add user only if it does not exist.

### DIFF
--- a/ncp.sh
+++ b/ncp.sh
@@ -123,7 +123,7 @@ EOF
   a2ensite ncp-activation
 
   ## NCP USER FOR AUTHENTICATION
-  useradd --home-dir /nonexistent "$WEBADMIN"
+  id -u "$WEBADMIN" &>/dev/null || useradd --home-dir /nonexistent "$WEBADMIN"
   echo -e "$WEBPASSWD\n$WEBPASSWD" | passwd "$WEBADMIN"
   chsh -s /usr/sbin/nologin "$WEBADMIN"
 


### PR DESCRIPTION
If user already exists, useradd ends with error and terminates the whole instalation process.