### PR TITLE
Update fail2ban.sh

### DIFF
--- a/bin/ncp/SECURITY/fail2ban.sh
+++ b/bin/ncp/SECURITY/fail2ban.sh
@@ -95,10 +95,10 @@ configure()
 
   cat > /etc/fail2ban/filter.d/nextcloud.conf <<'EOF'
 [INCLUDES]
-before = common.conf
+#before = common.conf
 
 [Definition]
-failregex = Login failed.*Remote IP.*<HOST>
+failregex = ^{.*Login failed: .* \(Remote IP: <HOST>\).*}$
 ignoreregex =
 EOF
 


### PR DESCRIPTION
Probable Fix for #1065 based on https://gist.github.com/GAS85/957e0b1a4f30120225a7be09b173eb24 and discussion in the ticket.
Try number 2.

I added Configuration that definitely work based on GIST and comment out #before = common.conf because based on comments it does not work with it. Have no idea why.