### PR TITLE
Exclude database directory from COW (on btrfs partitions)

### DIFF
--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -42,8 +42,8 @@ configure()
   
   # Set NOCOW flag on DBDIR if it is located on a btrfs file system
   mkdir -p "$DBDIR"
-  chown --reference="$SRCDIR"
-  chmod --reference="$SRCDIR"
+  chown --reference="$SRCDIR" "$DBDIR"
+  chmod --reference="$SRCDIR" "$DBDIR"
 
   grep -q -e btrfs <<<"$FSTYPE" && chattr +C "$DBDIR"
 

--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -31,6 +31,12 @@ configure()
   local BASEDIR=$( dirname "$DBDIR" )
   mkdir -p "$BASEDIR"
 
+  local FSTYPE="$(df -T /home/tknoeppl | cut -d " " -f2 | tail -n 1)"
+  if [[ $FSTYPE == "btrfs" ]]
+  then
+    chattr +C "$BASEDIR"
+  fi
+
   grep -q -e ext -e btrfs <( stat -fc%T "$BASEDIR" ) || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
   
   sudo -u mysql test -x "$BASEDIR" || { echo -e "ERROR: the user mysql does not have access permissions over $BASEDIR"; return 1; }

--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -55,7 +55,7 @@ configure()
   shopt -s dotglob
   mv "$SRCDIR"/* "$DBDIR/" && \
     sed -i "s|^datadir.*|datadir = $DBDIR|" /etc/mysql/mariadb.conf.d/90-ncp.cnf && \
-    rm -r "$SRCDIR"
+    rm -d "$SRCDIR"
   shopt -u dotglob
   service mysql start 
 

--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -33,7 +33,7 @@ configure()
 
   local FSTYPE="$( stat -fc%T "$BASEDIR" )"
 
-  grep -q -e btrfs <<<"$BASEDIR" && chattr +C "$BASEDIR"
+  grep -q -e btrfs <<<"$FSTYPE" && chattr +C "$BASEDIR"
 
   grep -q -e ext -e btrfs <<<"$BASEDIR" || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
   
@@ -72,4 +72,3 @@ install(){ :; }
 # along with this script; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330,
 # Boston, MA  02111-1307  USA
-

--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -33,9 +33,10 @@ configure()
 
   local FSTYPE="$( stat -fc%T "$BASEDIR" )"
 
-  grep -q -e btrfs <<<"$FSTYPE" && chattr +C "$BASEDIR"
-
-  grep -q -e ext -e btrfs <<<"$BASEDIR" || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
+  grep -q -e ext -e btrfs <<<"$FSTYPE" || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
+  
+  # Set NOCOW flag on DBDIR if it is located on a btrfs file system
+  grep -q -e btrfs <<<"$FSTYPE" && chattr +C "$DBDIR"
   
   sudo -u mysql test -x "$BASEDIR" || { echo -e "ERROR: the user mysql does not have access permissions over $BASEDIR"; return 1; }
 

--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -31,13 +31,11 @@ configure()
   local BASEDIR=$( dirname "$DBDIR" )
   mkdir -p "$BASEDIR"
 
-  local FSTYPE="$(df -T /home/tknoeppl | cut -d " " -f2 | tail -n 1)"
-  if [[ $FSTYPE == "btrfs" ]]
-  then
-    chattr +C "$BASEDIR"
-  fi
+  local FSTYPE="$( stat -fc%T "$BASEDIR" )"
 
-  grep -q -e ext -e btrfs <( stat -fc%T "$BASEDIR" ) || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
+  grep -q -e btrfs <<<"$BASEDIR" && chattr +C "$BASEDIR"
+
+  grep -q -e ext -e btrfs <<<"$BASEDIR" || { echo -e "Only ext/btrfs filesystems can hold the data directory"; return 1; }
   
   sudo -u mysql test -x "$BASEDIR" || { echo -e "ERROR: the user mysql does not have access permissions over $BASEDIR"; return 1; }
 


### PR DESCRIPTION
While reading through nc-database.sh, I thought that it might make sense to set the NO_COW flag on the db directory with chattr +C (because cow is not useful on large binary files and can heavily reduce performance).
This PR does precisely that. :)

I'm not entirely sure what happens when creating a btrfs snapshot, though. @nachoparker Do you think it might cause any issues?