### PR TITLE
add missing chown in install function for redis config, fixes 1019

### DIFF
--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -53,6 +53,7 @@ install()
   sed -i 's|# rename-command CONFIG ""|rename-command CONFIG ""|'  $REDIS_CONF
   sed -i "s|^port.*|port 0|"                                       $REDIS_CONF
   echo "maxmemory $REDIS_MEM" >> $REDIS_CONF
+  chown redis:redis $REDIS_CONF
   echo 'vm.overcommit_memory = 1' >> /etc/sysctl.conf
 
   usermod -a -G redis www-data


### PR DESCRIPTION
in #1021, I already mentioned we might have to change this. But I forgot about it.
Now, as I tried to install a new instance of nextcloudpi, this issue came up again :angry: 