### PR TITLE
Don't fail ncp-backup-auto

### DIFF
--- a/bin/ncp/BACKUPS/nc-backup-auto.sh
+++ b/bin/ncp/BACKUPS/nc-backup-auto.sh
@@ -40,7 +40,7 @@ fi
 EOF
   chmod +x /usr/local/bin/ncp-backup-auto
 
-  echo "0  3  */${BACKUPDAYS}  *  *  root  /usr/local/bin/ncp-backup-auto > /var/log/ncp-backup-auto.log 2>&1" > /etc/cron.d/ncp-backup-auto
+  echo "0  3  */${BACKUPDAYS}  *  *  root  /usr/local/bin/ncp-backup-auto > /var/log/ncp.log 2>&1" > /etc/cron.d/ncp-backup-auto
   chmod 644 /etc/cron.d/ncp-backup-auto
   service cron restart
 
@@ -65,4 +65,3 @@ install() { :; }
 # along with this script; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330,
 # Boston, MA  02111-1307  USA
-


### PR DESCRIPTION
Make sure the script don't return an exit status different from 0 so the
cron job doesn't send e-mails on failure, as notifications are being
delivered as Nextcloud notifications. Also redirect all output to a log
file, so in case of failure it is possible to review what happened.

This also makes the notification a bit more informative, as it says
which script failed.

The log files is overwritten on each run. This should not be a problem
since backups are run more frequently than once per day, so there should
be a fair amount of time to see the backup logs.