### PR TITLE
Don't fail ncp-autoupdate-apps cron if no updates

### DIFF
--- a/bin/ncp/UPDATES/nc-update-nc-apps-auto.sh
+++ b/bin/ncp/UPDATES/nc-update-nc-apps-auto.sh
@@ -29,7 +29,10 @@ echo "checking for updates..."
 echo "\$OUT" >> /var/log/ncp.log
 
 APPS=\$( echo "\$OUT" | grep 'updated\$' | awk '{ print \$1 }')
-[[ "\$APPS" != "" ]] && notify_admin "Apps updated" "\$APPS"
+if [[ "\$APPS" != "" ]]
+then
+  notify_admin "Apps updated" "\$APPS"
+fi
 EOF
   chmod 755 "$cronfile"
   echo "automatic app updates enabled"


### PR DESCRIPTION
If the `[[ "\$APPS" != "" ]]` check fails, the shell will use it's exit status as the whole script exit status, making the script return 1. Then cron thinks this job failed and sends an e-mail notification, which is not really providing any useful information as it only means nothing was updated.