### PR TITLE
Feature/encrypted backups

### DIFF
--- a/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Periodically sync Nextcloud datafolder through rsync, encrypted via duplicity
+#
+# Copyleft 2020 by Daniel Ploeger
+# 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/
+#
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y rsync
+  apt-get install --no-install-recommends -y duplicity
+}
+
+configure()
+{
+  [[ $ACTIVE != "yes" ]] && { 
+	rm -f /root/.passphrase
+    rm -f /etc/cron.d/ncp-rsync-encrypted-auto
+    echo "automatic encrypted rsync disabled"
+    return 0
+  }
+
+  local DATADIR
+  DATADIR=$( ncc config:system:get datadirectory ) || {
+    echo -e "Error reading data directory. Is NextCloud running and configured?";
+    return 1;
+  }
+
+  # Check if the ssh access is properly configured. For this purpose the command : or echo is called remotely.
+  # If one of the commands works, the test is successful.
+  [[ "$DESTINATION" =~ : ]] && {
+    local NET="$( sed 's|:.*||' <<<"$DESTINATION" )"
+    local SSH=( ssh -o "BatchMode=yes" -p "$PORTNUMBER" "$NET" )
+    ${SSH[@]} echo || { echo "SSH non-interactive not properly configured"; return 1; }
+  }
+  
+  # Create hidden file with passphrase in root home directory
+  echo "PASSPHRASE="$GPGPASSPHRASE"" > /root/.passphrase
+  chmod 700 /root/.passphrase
+  
+  echo -e "0  5  */${SYNCDAYSFULL}  *  *  root . /root/.passphrase;/usr/bin/duplicity full --rsync-options=\"-ax\" --ssh-options=\"-p $PORTNUMBER\" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION";/usr/bin/duplicity remove-all-but-n-full 1 --ssh-options=\"-p $PORTNUMBER\" --encrypt-key="$GPGKEY" --force rsync://$"DESTINATION";unset PASSPHRASE\n0  4  */${SYNCDAYSINCR}  *  *  root  . /root/.passphrase;/usr/bin/duplicity --rsync-options=\"-ax\" --ssh-options=\"-p $PORTNUMBER\" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION";unset PASSPHRASE" > /etc/cron.d/ncp-rsync-encrypted-auto
+  chmod 644 /etc/cron.d/ncp-rsync-encrypted-auto
+  service cron restart
+
+  echo "automatic encrypted rsync enabled"
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA
+

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
@@ -72,10 +72,13 @@ sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
   duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://"$DESTINATION"database
   rm /var/www/"$dbbackup"
 }
+sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
 [[ "$INCLUDEDATA" == "yes" ]] && { 
   datadestination="/$( sed 's|.*//||' <<<$DESTINATION )"/data
-  duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"data
+  duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" --asynchronous-upload "$DATADIR" rsync://"$DESTINATION"data
   duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://"$DESTINATION"data
+  sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
+  duplicity --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" --asynchronous-upload "$DATADIR" rsync://"$DESTINATION"data
 }
 sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
 unset PASSPHRASE
@@ -109,9 +112,12 @@ sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
   duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://"$DESTINATION"database
   rm /var/www/"$dbbackup"
 }
+sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
 [[ "$INCLUDEDATA" == "yes" ]] && { 
   datadestination="/$( sed 's|.*//||' <<<$DESTINATION )"/data
-  duplicity --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"data
+  duplicity --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" --asynchronous-upload "$DATADIR" rsync://"$DESTINATION"data
+  sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
+  duplicity --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" --asynchronous-upload "$DATADIR" rsync://"$DESTINATION"data
 }
 sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
 unset PASSPHRASE

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
@@ -105,7 +105,7 @@ sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
   dbdestination="/$( sed 's|.*//||' <<<$DESTINATION )"/database
   dbbackup=nextcloud-sqlbkp_$( date +"%Y%m%d" ).bak
   mysqldump --single-transaction nextcloud > /var/www/"$dbbackup"
-  duplicity --rsync-options="-ax --rsync-path=\"mkdir -p \"$dbdestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" /var/www/"$dbbackup" rsync://"$DESTINATION"database
+  duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$dbdestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" /var/www/"$dbbackup" rsync://"$DESTINATION"database
   rm /var/www/"$dbbackup"
 }
 [[ "$INCLUDEDATA" == "yes" ]] && { 

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
@@ -118,7 +118,7 @@ EOF
   chmod 755 /usr/local/bin/ncp-rsync-encrypted-incr
   
   # Create cron entry to call sync files
-  echo -e "0  5  */${SYNCDAYSFULL}  *  *  root /usr/local/bin/ncp-rsync-encrypted-full -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB\n0  4  */${SYNCDAYSINCR}  *  *  root /usr/local/bin/ncp-rsync-encrypted-incr -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB" > /etc/cron.d/ncp-rsync-encrypted-auto
+  echo -e "30  4  */${SYNCDAYSFULL}  *  *  root /usr/local/bin/ncp-rsync-encrypted-full -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB\n0  5  */${SYNCDAYSINCR}  *  *  root /usr/local/bin/ncp-rsync-encrypted-incr -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB" > /etc/cron.d/ncp-rsync-encrypted-auto
   chmod 644 /etc/cron.d/ncp-rsync-encrypted-auto
   service cron restart
 

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted-auto.sh
@@ -75,7 +75,7 @@ sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
 [[ "$INCLUDEDATA" == "yes" ]] && { 
   datadestination="/$( sed 's|.*//||' <<<$DESTINATION )"/data
   duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"data
-  duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://$"DESTINATION"data
+  duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://"$DESTINATION"data
 }
 sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --off
 unset PASSPHRASE
@@ -106,6 +106,7 @@ sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on
   dbbackup=nextcloud-sqlbkp_$( date +"%Y%m%d" ).bak
   mysqldump --single-transaction nextcloud > /var/www/"$dbbackup"
   duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$dbdestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" /var/www/"$dbbackup" rsync://"$DESTINATION"database
+  duplicity remove-all-but-n-full 1 --ssh-options="-p $PORTNUMBER" --encrypt-key="$GPGKEY" --force rsync://"$DESTINATION"database
   rm /var/www/"$dbbackup"
 }
 [[ "$INCLUDEDATA" == "yes" ]] && { 
@@ -118,7 +119,7 @@ EOF
   chmod 755 /usr/local/bin/ncp-rsync-encrypted-incr
   
   # Create cron entry to call sync files
-  echo -e "30  4  */${SYNCDAYSFULL}  *  *  root /usr/local/bin/ncp-rsync-encrypted-full -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB\n0  5  */${SYNCDAYSINCR}  *  *  root /usr/local/bin/ncp-rsync-encrypted-incr -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB" > /etc/cron.d/ncp-rsync-encrypted-auto
+  echo -e "0  ${SYNCTIMEFULL}  */${SYNCDAYSFULL}  *  *  root /usr/local/bin/ncp-rsync-encrypted-full -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB\n0  ${SYNCTIMEINCR}  */${SYNCDAYSINCR}  *  *  root /usr/local/bin/ncp-rsync-encrypted-incr -p $PORTNUMBER -k $GPGKEY -s $DATADIR -d $DESTINATION -D $INCLUDEDATA -B $INCLUDEDB" > /etc/cron.d/ncp-rsync-encrypted-auto
   chmod 644 /etc/cron.d/ncp-rsync-encrypted-auto
   service cron restart
 

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted.sh
@@ -45,7 +45,7 @@ configure()
   }
   [[ "$INCLUDEDATA" == "yes" ]] && {
     datadestination="/$( sed 's|.*//||' <<<$DESTINATION )"/data 
-    ( duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"data ) || {
+    ( duplicity full --rsync-options="-ax --rsync-path=\"mkdir -p \"$datadestination\" && rsync\"" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" --asynchronous-upload "$DATADIR" rsync://"$DESTINATION"data ) || {
       echo -e "If incomplete backup sets exist in the remote folder please continue the backup manually with the command:\n\nduplicity full --rsync-options=\"-ax\" --ssh-options=\"-p $PORTNUMBER\" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"data\n";
 	  sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --off;
       return 1;

--- a/bin/ncp/BACKUPS/nc-rsync-encrypted.sh
+++ b/bin/ncp/BACKUPS/nc-rsync-encrypted.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Sync Nextcloud datafolder through rsync, encrypted via duplicity
+#
+# Copyleft 2020 by Daniel Ploeger
+# 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at https://ownyourbits.com/2017/02/13/nextcloud-ready-raspberry-pi-image/
+#
+
+BASEDIR=/var/www
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y rsync openssh-client
+  apt-get install --no-install-recommends -y duplicity
+}
+
+configure()
+{
+  sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --on
+
+  local DATADIR
+  DATADIR=$( sudo -u www-data php /var/www/nextcloud/occ config:system:get datadirectory ) || {
+    echo -e "Error reading data directory. Is NextCloud running and configured?";
+    return 1;
+  }
+  
+  ( duplicity full --rsync-options="-ax" --ssh-options="-p $PORTNUMBER" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION" ) || {
+    echo -e "If incomplete backup sets exist in the remote folder please continue the backup manually with the command:\n\nduplicity full --rsync-options=\"-ax\" --ssh-options=\"-p $PORTNUMBER\" --encrypt-key "$GPGKEY" "$DATADIR" rsync://"$DESTINATION"\n";
+	sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --off;
+    return 1;
+  }
+
+  sudo -u www-data php "$BASEDIR"/nextcloud/occ maintenance:mode --off
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA
+

--- a/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
@@ -52,25 +52,25 @@
       "id": "SYNCDAYSFULL",
       "name": "Full sync periodicity (in days).",
       "value": "",
-      "suggest": "30"
+      "suggest": "90"
     },
     {
       "id": "SYNCTIMEFULL",
       "name": "Full sync hour of day.",
       "value": "",
-      "suggest": "2"
+      "suggest": "5"
     },
     {
       "id": "SYNCDAYSINCR",
       "name": "Incremental sync periodicity (in days)",
       "value": "",
       "suggest": "3"
-    }
+    },
     {
       "id": "SYNCTIMEINCR",
       "name": "Incremental sync hour of day.",
       "value": "",
-      "suggest": "3"
-    },
+      "suggest": "5"
+    }
   ]
 }

--- a/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
@@ -1,0 +1,52 @@
+{
+  "id": "nc-rsync-encrypted-auto",
+  "name": "Nc-rsync-encrypted-auto",
+  "title": "nc-rsync-encrypted-auto",
+  "description": "Periodically create and sync full GnuPG-encrypted Nextcloud data backup through duplicity and rsync",
+  "info": "'user' needs SSH autologin from the NCP 'root' user at 'ip'.\nNCP 'root' user needs to have a GPG key generated and stored.\nFor longer full sync periodicity the backup size increases more over time.",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "ACTIVE",
+      "name": "Active",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "DESTINATION",
+      "name": "Destination",
+      "value": "user@ip//path/to/sync",
+      "suggest": "user@ip//path/to/sync"
+    },
+    {
+      "id": "PORTNUMBER",
+      "name": "SSH port number",
+      "value": "22",
+      "suggest": "22"
+    },
+    {
+      "id": "GPGKEY",
+      "name": "GPG key ID",
+      "value": "",
+      "suggest": ""
+    },
+    {
+      "id": "GPGPASSPHRASE",
+      "name": "GPG passphrase",
+      "value": "",
+      "suggest": ""
+    },
+    {
+      "id": "SYNCDAYSFULL",
+      "name": "Full sync periodicity (in days).",
+      "value": "30",
+      "suggest": "30"
+    },
+    {
+      "id": "SYNCDAYSINCR",
+      "name": "Incremental sync periodicity (in days)",
+      "value": "3",
+      "suggest": "3"
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
@@ -9,31 +9,43 @@
     {
       "id": "ACTIVE",
       "name": "Active",
-      "value": "no",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
+      "id": "INCLUDEDB",
+      "name": "Include database",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
+      "id": "INCLUDEDATA",
+      "name": "Include data",
+      "value": "yes",
       "type": "bool"
     },
     {
       "id": "DESTINATION",
       "name": "Destination",
-      "value": "user@ip//path/to/sync",
+      "value": "backupuser@192.168.2.112//volume1/NetBackup/cloud/",
       "suggest": "user@ip//path/to/sync"
     },
     {
       "id": "PORTNUMBER",
       "name": "SSH port number",
-      "value": "22",
+      "value": "33",
       "suggest": "22"
     },
     {
       "id": "GPGKEY",
       "name": "GPG key ID",
-      "value": "",
+      "value": "6EB1B06711126A8D38B5D6BFB226850012662BE3",
       "suggest": ""
     },
     {
       "id": "GPGPASSPHRASE",
       "name": "GPG passphrase",
-      "value": "",
+      "value": "JrzUOVN7Y3ZKEDjihdynkGefFXwPx8Afp2lHRcWTq6a5CIv0utSMQBsmL924g1ob",
       "suggest": ""
     },
     {
@@ -45,7 +57,7 @@
     {
       "id": "SYNCDAYSINCR",
       "name": "Incremental sync periodicity (in days)",
-      "value": "3",
+      "value": "1",
       "suggest": "3"
     }
   ]

--- a/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted-auto.cfg
@@ -27,38 +27,50 @@
     {
       "id": "DESTINATION",
       "name": "Destination",
-      "value": "backupuser@192.168.2.112//volume1/NetBackup/cloud/",
+      "value": "",
       "suggest": "user@ip//path/to/sync"
     },
     {
       "id": "PORTNUMBER",
       "name": "SSH port number",
-      "value": "33",
+      "value": "",
       "suggest": "22"
     },
     {
       "id": "GPGKEY",
       "name": "GPG key ID",
-      "value": "6EB1B06711126A8D38B5D6BFB226850012662BE3",
+      "value": "",
       "suggest": ""
     },
     {
       "id": "GPGPASSPHRASE",
       "name": "GPG passphrase",
-      "value": "JrzUOVN7Y3ZKEDjihdynkGefFXwPx8Afp2lHRcWTq6a5CIv0utSMQBsmL924g1ob",
+      "value": "",
       "suggest": ""
     },
     {
       "id": "SYNCDAYSFULL",
       "name": "Full sync periodicity (in days).",
-      "value": "30",
+      "value": "",
       "suggest": "30"
+    },
+    {
+      "id": "SYNCTIMEFULL",
+      "name": "Full sync hour of day.",
+      "value": "",
+      "suggest": "2"
     },
     {
       "id": "SYNCDAYSINCR",
       "name": "Incremental sync periodicity (in days)",
-      "value": "1",
+      "value": "",
       "suggest": "3"
     }
+    {
+      "id": "SYNCTIMEINCR",
+      "name": "Incremental sync hour of day.",
+      "value": "",
+      "suggest": "3"
+    },
   ]
 }

--- a/etc/ncp-config.d/nc-rsync-encrypted.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted.cfg
@@ -1,0 +1,28 @@
+{
+  "id": "nc-rsync-encrypted",
+  "name": "Nc-rsync-encrypted",
+  "title": "nc-rsync-encrypted",
+  "description": "Create and sync full GnuPG-encrypted Nextcloud data backup through duplicity and rsync",
+  "info": "'user' needs SSH autologin from the NCP 'root' user at 'ip'.\nNCP 'root' user needs to have a GPG key generated and stored.\nPrevious duplicity backups are not deleted.",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "DESTINATION",
+      "name": "Destination",
+      "value": "user@ip//path/to/sync",
+      "suggest": "user@ip//path/to/sync"
+    },
+    {
+      "id": "PORTNUMBER",
+      "name": "SSH port number",
+      "value": "22",
+      "suggest": "22"
+    },
+    {
+      "id": "GPGKEY",
+      "name": "GPG key ID",
+      "value": "",
+      "suggest": ""
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-rsync-encrypted.cfg
+++ b/etc/ncp-config.d/nc-rsync-encrypted.cfg
@@ -7,6 +7,18 @@
   "infotitle": "",
   "params": [
     {
+      "id": "INCLUDEDB",
+      "name": "Include database",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
+      "id": "INCLUDEDATA",
+      "name": "Include data",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
       "id": "DESTINATION",
       "name": "Destination",
       "value": "user@ip//path/to/sync",


### PR DESCRIPTION
Hello, I felt that NCP was lacking a proper backup solution with encrypted containers, which can be synchronized to an untrusted remote destination.

For this reason I implemented the scripts `nc-rsync-encrypted` and `nc-rsync-encrypted-auto` during the last days. The scripts are tested, but not exhaustively. The features are: 

- A full encrypted backup can be sent to a remote destination one-time with `nc-rsync-encrypted`
- Encrypted backups can be sent to a remote destination on a regular basis with `nc-rsync-encrypted-auto`
- Either NC data or database or both can be backed up
- The encrypted backups use duplicity via rsync; an existing GPG key on the NCP server is required
- The auto backup is configured with full sync and incremental sync periodicities. The incremental syncs are faster, but increase the backup size at the remote destination with each backup. On the other hand, the full syncs do not keep outdated/dispensable data on the remote destination
- The one-time backup doesn't store any confidential information (due to GPG asymmetric encryption). This limits the backup to single backups per remote destination, because the metadata of previous backups can't be decrypted.
- The auto backup stores the GPG passphrase in a hidden file in the root home directory, only accessible by the NCP root user. This allows for regular full and incremental backups
- Note the slightly different destination path syntax on the web interface compared to `rc-rsync`. Instead of rsync access via remote shell, the destination is accessed via the rsync daemon to allow duplicity usage
- Suggestion for the docs.nextcloudpi.com configuration reference:
```
Step 1: follow the connection setup reference for nc-rsync.

Step 2: on the NCP server, generate a GPG key pair with the following command:

gpg --gen-key

During the key generation process you are asked to enter a passphrase. Note it down at a safe place. This is required if you ever want to restore your backup. The public key is stored at /root/.gnupg/, to get a list of all keys use the following command:

gpg --list-keys

The list shows the GPG key ID, a long hexadecimal hash value. Paste this value to the respective field of nc-rsync-encrypted or nc-rsync-encrypted-auto. 
```
- Additional paragraph for the docs.nextcloudpi.com configuration reference of `nc-rsync-encrypted-auto`:
```
In nc-rsync-encrypted-auto, enter your passphrase to the GPG passphrase field. The auto backup stores the GPG passphrase in a hidden file in the root home directory, only accessible by the NCP root user. This allows for regular full and incremental backups. Choose full sync and incremental sync periodicities. The incremental syncs are faster, but increase the backup size at the remote destination with each backup. On the other hand, the full syncs do not keep outdated/dispensable data on the remote destination.
```
- Future work: implement the restore functionality, add localisation, add additional usage checks for unexpected duplicity behavior.