### PR TITLE
Make ncp-autoupdate cronjob write to the log

### DIFF
--- a/bin/ncp/UPDATES/nc-autoupdate-ncp.sh
+++ b/bin/ncp/UPDATES/nc-autoupdate-ncp.sh
@@ -20,6 +20,9 @@ configure()
   cat > /etc/cron.daily/ncp-autoupdate <<EOF
 #!/bin/bash
 source /usr/local/etc/library.sh
+# Forward all output to the ncp log
+exec > /var/log/ncp.log 2>&1
+echo "\$(date) - Running \$0..."
 if /usr/local/bin/ncp-test-updates; then
   /usr/local/bin/ncp-update || exit 1
   notify_admin "NextCloudPi" "NextCloudPi was updated to \$(cat /usr/local/etc/ncp-version)"


### PR DESCRIPTION
Cronjobs should not have any output, unless the cronjob fails, otherwise an e-mail notification is sent with the output. This cronjob in particular is also reporting results via Nextcloud notification, so having an e-mail with logs saying the same as the notification is not particularly useful. Instead we just redirect all output to the /var/log/ncp.log so the user can debug in case of problems and doesn't receive spurious e-mails when all works fine.