### PR TITLE
Reverse proxy and hsts improvements

### DIFF
--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -210,6 +210,14 @@ EOF
     RewriteCond %{HTTPS} !=on
     RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
   </IfModule>
+  <Directory /var/www/nextcloud/>
+    Options +FollowSymlinks
+    AllowOverride All
+    <IfModule mod_dav.c>
+      Dav off
+    </IfModule>
+    LimitRequestBody 0
+  </Directory>
 </VirtualHost>
 EOF
 

--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -196,8 +196,6 @@ EOF
   <IfModule mod_headers.c>
     Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
   </IfModule>
-EOF
-
 </IfModule>
 EOF
   a2ensite nextcloud

--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -193,6 +193,11 @@ EOF
     LimitRequestBody 0
     SSLRenegBufferSize 10486000
   </Directory>
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
+  </IfModule>
+EOF
+
 </IfModule>
 EOF
   a2ensite nextcloud

--- a/lamp.sh
+++ b/lamp.sh
@@ -75,12 +75,6 @@ SSLStaplingReturnResponderErrors off
 SSLStaplingCache        shmcb:/var/run/ocsp(128000)
 EOF
 
-    cat >> /etc/apache2/apache2.conf <<EOF
-<IfModule mod_headers.c>
-  Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
-</IfModule>
-EOF
-
     # CONFIGURE PHP7
     ##########################################
 

--- a/ncp.sh
+++ b/ncp.sh
@@ -73,6 +73,9 @@ Listen 4443
   SSLEngine on
   SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem
   SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
+  </IfModule>
 
   # 2 days to avoid very big backups requests to timeout
   TimeOut 172800


### PR DESCRIPTION
This should solve issue #777 and use more sensible defaults for the hsts header (that is ignored anyway when not served over https)