### PR TITLE
Fix the style of the language selection dropdown.

### DIFF
--- a/ncp-web/css/ncp.css
+++ b/ncp-web/css/ncp.css
@@ -1377,6 +1377,10 @@ a#versionlink:hover {
 
 #language-selection {
   border: none;
+}
+
+/* Show selected language in white color because the background is blue. If the selection is active, don't change the color because the background is white. */
+#language-selection:not(:active) {
   color: white;
 }
 


### PR DESCRIPTION
If the language selection is active the background color as well as the color was white and therefore the language options were unreadable.
Only Chrome is affected (tested with Chromium Version 84.0.4147.105), Firefox is ok.
![ncp language selection bug](https://user-images.githubusercontent.com/1099794/91643285-0fa5a600-ea32-11ea-9f20-a45d3702ec85.gif)

Fix by setting the color to white only if selection is not active.
![ncp language selection fixed](https://user-images.githubusercontent.com/1099794/91643286-116f6980-ea32-11ea-94ba-b804f0653040.gif)