### PR TITLE
Bump ncp-previewgenerator version to 102.2.1

### DIFF
--- a/ncp-previewgenerator/appinfo/info.xml
+++ b/ncp-previewgenerator/appinfo/info.xml
@@ -13,7 +13,7 @@ The first time you activate this app through 'nc-previews-auto', you properly wa
 	</description>
 	<licence>AGPL</licence>
 	<author>Roeland Jago Douma and Ignacio Nunez</author>
-	<version>102.2.0</version>
+	<version>102.2.1</version>
 	<namespace>PreviewGenerator</namespace>
 	<category>multimedia</category>
 	<website>https://nextcloudpi.com</website>


### PR DESCRIPTION
**Disclaimer:** I'm not a Nextcloud developer so I'm not sure if this fix is OK. For more context, I upgraded my ncp instance from NC 18 to NC 19 and now the apps management page says that the app `NCP Preview Generator` at version `102.2.0` is not marked as compatible with NC 19. Checking `/var/www/nextcloud/apps/previewgenerator/appinfo/info.xml`, I see it has the tag `<nextcloud min-version="14" max-version="18" />` and version `<version>102.2.0</version>`.

I checked this repository to see if I was missing a new version of the app, and I see the version in the current master is still 102.2.0 but the NC support was updated to `<nextcloud min-version="14" max-version="19" />`, so I'm assuming that, for an upgrade to happen, the version needs to be actually bumped.

If this is not the correct fix, please let me know how can I get the updated version.

Thanks!