### PR TITLE
Namecheap dynamic DNS client

### DIFF
--- a/README-ZH-TW.md
+++ b/README-ZH-TW.md
@@ -51,6 +51,7 @@ NextCloudPi 是專門為 Raspberry Pi、Odroid HC1、rock64 以及其它單板�
  * 可使用freeDNS 所提供的浮動IP連結功能
  * 可使用duckDNS 所提供的浮動IP連結功能
  * 可使用spDYN 所提供的浮動IP連結功能
+ * 可使用Namecheap DNS 所提供的浮動IP連結功能
  * 內建 dnsmasq DNS 伺服器快取
  * ModSecurity 網路應用程式防火牆
  * NFS ready to mount your files over LAN

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Find the full documentation at [docs.nextcloudpi.com](http://docs.nextcloudpi.co
  * Dynamic DNS support for freeDNS
  * Dynamic DNS support for duckDNS
  * Dynamic DNS support for spDYN
+ * Dynamic DNS support for Namecheap
  * dnsmasq DNS server with DNS cache
  * ModSecurity Web Application Firewall
  * NFS ready to mount your files over LAN

--- a/bin/ncp/NETWORKING/namecheapDNS.sh
+++ b/bin/ncp/NETWORKING/namecheapDNS.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Namecheap DNS updater client installation on Raspbian 
+#
+# Copyleft 2020 by ndunks and Huizerd
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# Based on:
+# - https://gist.github.com/ndunks/c756030c0757b667c9a478c97ca5a9b7
+# - https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-do-i-use-a-browser-to-dynamically-update-the-hosts-ip
+#
+# Further steps to be taken:
+# - Buying a Namecheap domain
+# - https://www.namecheap.com/support/knowledgebase/article.aspx/595/11/how-do-i-enable-dynamic-dns-for-a-domain/
+# - https://www.namecheap.com/support/knowledgebase/article.aspx/43/11/how-do-i-set-up-a-host-for-dynamic-dns
+
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y dnsutils
+}
+
+configure() 
+{
+  local updateurl=https://dynamicdns.park-your-domain.com/update
+  local url="${updateurl}?host=${HOST}&domain=${DOMAIN}&password=${PASSWORD}"
+
+  [[ $ACTIVE != "yes" ]] && { 
+    rm -f /etc/cron.d/namecheapDNS
+    service cron restart
+    echo "Namecheap DNS client is disabled"
+    return 0
+  }
+
+  cat > /usr/local/bin/namecheapdns.sh <<EOF
+#!/bin/bash
+echo "Namecheap DNS client started"
+registeredIP=\$(dig +short "$FULLDOMAIN"|tail -n1)
+currentIP=\$(wget -q -O - http://checkip.dyndns.org|sed s/[^0-9.]//g)
+echo "${url}&ip=${currentIP}"
+    [ "\$currentIP" != "\$registeredIP" ] && {
+        wget -q -O /dev/null "${url}&ip=${currentIP}"
+  }
+echo "Registered IP: \$registeredIP | Current IP: \$currentIP"
+EOF
+  chmod +744 /usr/local/bin/namecheapdns.sh
+
+  echo "*/${UPDATEINTERVAL}  *  *  *  *  root  /bin/bash /usr/local/bin/namecheapdns.sh" > /etc/cron.d/namecheapDNS
+  chmod 644 /etc/cron.d/namecheapDNS
+  service cron restart
+
+  cd /var/www/nextcloud
+  sudo -u www-data php occ config:system:set trusted_domains 3 --value="$FULLDOMAIN"
+  sudo -u www-data php occ config:system:set overwrite.cli.url --value=https://"$FULLDOMAIN"/
+
+  echo "Namecheap DNS client is enabled"
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/etc/ncp-config.d/namecheapDNS.cfg
+++ b/etc/ncp-config.d/namecheapDNS.cfg
@@ -1,0 +1,46 @@
+{
+  "id": "namecheapDNS",
+  "name": "Dynamic DNS from Namecheap",
+  "title": "namecheapDNS",
+  "description": "Namecheap Dynamic DNS service (need domain from https://www.namecheap.com/)",
+  "info": "First, complete these steps: https://www.namecheap.com/support/knowledgebase/article.aspx/595/11/how-do-i-enable-dynamic-dns-for-a-domain/ and https://www.namecheap.com/support/knowledgebase/article.aspx/43/11/how-do-i-set-up-a-host-for-dynamic-dns",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "ACTIVE",
+      "name": "Active",
+      "value": "no",
+      "type": "bool"
+    },
+    {
+      "id": "PASSWORD",
+      "name": "Dynamic DNS password",
+      "value": "",
+      "suggest": "840deed9ef1844eca7c198df2d31bf10"
+    },
+    {
+      "id": "FULLDOMAIN",
+      "name": "Full domain name ('host.domain' if host is not '@', else domain)",
+      "value": "",
+      "suggest": "mynextcloud.example.com"
+    },
+    {
+      "id": "HOST",
+      "name": "Host name (enter '@' if you only want 'example.com')",
+      "value": "",
+      "suggest": "mynextcloud"
+    },
+    {
+      "id": "DOMAIN",
+      "name": "Domain name",
+      "value": "",
+      "suggest": "example.com"
+    },
+    {
+      "id": "UPDATEINTERVAL",
+      "name": "Update periodicity (in minutes)",
+      "value": "30",
+      "suggest": "30"
+    }
+  ]
+}


### PR DESCRIPTION
Dynamic DNS client for Namecheap domains. Approach largely copied from the existing freeDNS script, adjusted according to [this gist](https://gist.github.com/ndunks/c756030c0757b667c9a478c97ca5a9b7) and [Namecheap docs](https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-do-i-use-a-browser-to-dynamically-update-the-hosts-ip)