### PR TITLE
nc-autoupdate-ncp: Append to log instead of replace

### DIFF
--- a/bin/ncp/UPDATES/nc-autoupdate-ncp.sh
+++ b/bin/ncp/UPDATES/nc-autoupdate-ncp.sh
@@ -21,7 +21,7 @@ configure()
 #!/bin/bash
 source /usr/local/etc/library.sh
 # Forward all output to the ncp log
-exec > /var/log/ncp.log 2>&1
+exec >> /var/log/ncp.log 2>&1
 echo "\$(date) - Running \$0..."
 if /usr/local/bin/ncp-test-updates; then
   /usr/local/bin/ncp-update || exit 1


### PR DESCRIPTION
The log is being replaced on each run instead of appended to.