### PR TITLE
[complete] Implement ncp-app for prometheus (system) metrics

### DIFF
--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -179,6 +179,7 @@ EOF
     echo "ERROR: An error occured while generating the nextcloud apache2 config. Attempting safe mode..."
     bash /usr/local/etc/nextcloud.conf.sh --defaults > /etc/apache2/sites-available/nextcloud.conf || {
       echo "ERROR: Safe mode templating failed as well. Nextcloud will not work."
+      exit 1
     }
   }
   a2ensite nextcloud

--- a/bin/ncp/CONFIG/nc-nextcloud.sh
+++ b/bin/ncp/CONFIG/nc-nextcloud.sh
@@ -175,30 +175,12 @@ EOF
 
 ## SET APACHE VHOST
   echo "Setting up Apache..."
-  cat > /etc/apache2/sites-available/nextcloud.conf <<'EOF'
-<IfModule mod_ssl.c>
-  <VirtualHost _default_:443>
-    DocumentRoot /var/www/nextcloud
-    CustomLog /var/log/apache2/nc-access.log combined
-    ErrorLog  /var/log/apache2/nc-error.log
-    SSLEngine on
-    SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem
-    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
-  </VirtualHost>
-  <Directory /var/www/nextcloud/>
-    Options +FollowSymlinks
-    AllowOverride All
-    <IfModule mod_dav.c>
-      Dav off
-    </IfModule>
-    LimitRequestBody 0
-    SSLRenegBufferSize 10486000
-  </Directory>
-  <IfModule mod_headers.c>
-    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
-  </IfModule>
-</IfModule>
-EOF
+  bash /usr/local/etc/nextcloud.conf.sh > /etc/apache2/sites-available/nextcloud.conf || {
+    echo "ERROR: An error occured while generating the nextcloud apache2 config. Attempting safe mode..."
+    bash /usr/local/etc/nextcloud.conf.sh --defaults > /etc/apache2/sites-available/nextcloud.conf || {
+      echo "ERROR: Safe mode templating failed as well. Nextcloud will not work."
+    }
+  }
   a2ensite nextcloud
 
   cat > /etc/apache2/sites-available/000-default.conf <<'EOF'

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -54,11 +54,6 @@ configure()
   local DOMAIN_LOWERCASE="${DOMAIN,,}"
 
   [[ "$DOMAIN" == "" ]] && { echo "empty domain"; return 1; }
-#
-#  # Configure Apache
-#  grep -q ServerName $nc_vhostcfg && \
-#    sed -i "s|ServerName .*|ServerName $DOMAIN|" $nc_vhostcfg || \
-#    sed -i "/DocumentRoot/aServerName $DOMAIN" $nc_vhostcfg
 
   # Do it
   local domain_string=""

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -9,13 +9,20 @@
 
 
 ncdir=/var/www/nextcloud
-vhostcfg=/etc/apache2/sites-available/nextcloud.conf
+nc_vhostcfg=/etc/apache2/sites-available/nextcloud.conf
 vhostcfg2=/etc/apache2/sites-available/ncp.conf
 letsencrypt=/usr/bin/letsencrypt
 
 is_active()
 {
   [[ $( find /etc/letsencrypt/live/ -maxdepth 0 -empty | wc -l ) == 0 ]]
+}
+
+tmpl_letsencrypt_domain() {
+  (
+  . /usr/local/etc/library.sh
+  is_active && find_app_param letsencrypt DOMAIN
+  )
 }
 
 install()
@@ -47,11 +54,11 @@ configure()
   local DOMAIN_LOWERCASE="${DOMAIN,,}"
 
   [[ "$DOMAIN" == "" ]] && { echo "empty domain"; return 1; }
-
-  # Configure Apache
-  grep -q ServerName $vhostcfg && \
-    sed -i "s|ServerName .*|ServerName $DOMAIN|" $vhostcfg || \
-    sed -i "/DocumentRoot/aServerName $DOMAIN" $vhostcfg
+#
+#  # Configure Apache
+#  grep -q ServerName $nc_vhostcfg && \
+#    sed -i "s|ServerName .*|ServerName $DOMAIN|" $nc_vhostcfg || \
+#    sed -i "/DocumentRoot/aServerName $DOMAIN" $nc_vhostcfg
 
   # Do it
   local domain_string=""
@@ -94,9 +101,7 @@ EOF
     chmod +x /etc/letsencrypt/renewal-hooks/deploy/ncp
 
     # Configure Apache
-    sed -i "s|SSLCertificateFile.*|SSLCertificateFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/fullchain.pem|" $vhostcfg
-    sed -i "s|SSLCertificateKeyFile.*|SSLCertificateKeyFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/privkey.pem|" $vhostcfg
-
+    bash /usr/local/etc/ncp-templates/nextcloud.conf.sh > ${nc_vhostcfg}
     sed -i "s|SSLCertificateFile.*|SSLCertificateFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/fullchain.pem|" $vhostcfg2
     sed -i "s|SSLCertificateKeyFile.*|SSLCertificateKeyFile /etc/letsencrypt/live/$DOMAIN_LOWERCASE/privkey.pem|" $vhostcfg2
 

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -21,7 +21,10 @@ is_active()
 tmpl_letsencrypt_domain() {
   (
   . /usr/local/etc/library.sh
-  is_active && find_app_param letsencrypt DOMAIN
+  if is_active
+  then
+    find_app_param letsencrypt DOMAIN
+  fi
   )
 }
 

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+is_active() {
+  return 1
+}
+
+tmpl_metrics_enabled() {
+  (
+  . /usr/local/etc/library.sh
+  local param_active="$(find_app_param metrics.sh ACTIVE)"
+  [[ "$param_active" == yes ]] || exit 1
+  )
+}
+
+install() {
+
+  # Subshell to return on failure  instead of exiting (due to set -e)
+  (
+
+  set -e
+  cp /usr/local/etc/ncp-templates/prometheus-node-exporter.defaults /etc/default/prometheus-node-exporter
+  apt-get update && apt-get install -y --no-install-recommends prometheus-node-exporter
+    service prometheus-node-exporter disable
+    service prometheus-node-exporter stop
+
+  a2enmod proxy_http
+
+  )
+}
+
+configure() {
+
+  if [[ "$ACTIVE" != yes ]]
+  then
+    bash /usr/local/etc/ncp-templates/nextcloud.conf.sh --defaults > /etc/apache2/sites-available/nextcloud.conf
+
+    service prometheus-node-exporter disable
+    service prometheus-node-exporter stop
+  else
+    [[ -n "$USER" ]] || {
+      echo "ERROR: User can not be empty!" >&2
+      return 1
+    }
+
+    [[ -n "$PASSWORD" ]] || {
+      echo "ERROR: Password can not be empty!" >&2
+      return 1
+    }
+
+    [[ ${#PASSWORD} -ge 10 ]] || {
+      echo "ERROR: Password must be at least 10 characters long!" >&2
+      return 1
+    }
+
+    local htpasswd_file="/usr/local/etc/metrics.htpasswd"
+    [[ -f "${htpasswd_file}" ]] && rm "${htpasswd_file}"
+    echo "$PASSWORD" | htpasswd -ciB "${htpasswd_file}" metrics
+
+    bash /usr/local/etc/ncp-templates/nextcloud.conf.sh > /etc/apache2/sites-available/nextcloud.conf || {
+      echo "An unexpected error occurred while configuring apache. Rolling back..." >&2
+      bash /usr/local/etc/ncp-templates/nextcloud.conf.sh --defaults > /etc/apache2/sites-available/nextcloud.conf
+      return 1
+    }
+
+    service prometheus-node-exporter enable
+    service prometheus-node-exporter start
+
+    echo "Metric endpoint enabled. You can test it at https://nextcloudpi.local/metrics/system (or under your NC domain under the same path)"
+  fi
+  service apache2 reload
+
+
+}

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -21,12 +21,9 @@ install() {
   cp /usr/local/etc/ncp-templates/prometheus-node-exporter.defaults /etc/default/prometheus-node-exporter
   apt-get update && apt-get install -y --no-install-recommends prometheus-node-exporter
 
-  a2enmod proxy_http
-
   # TODO: Docker support?
   systemctl disable prometheus-node-exporter
   service prometheus-node-exporter stop
-  service apache2 restart
 
   )
 }

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -23,7 +23,8 @@ install() {
 
   a2enmod proxy_http
 
-  service prometheus-node-exporter disable
+  # TODO: Docker support?
+  systemctl disable prometheus-node-exporter
   service prometheus-node-exporter stop
   service apache2 restart
 
@@ -36,7 +37,7 @@ configure() {
   then
     bash /usr/local/etc/ncp-templates/nextcloud.conf.sh --defaults > /etc/apache2/sites-available/nextcloud.conf
 
-    service prometheus-node-exporter disable
+    systemctl disable prometheus-node-exporter
     service prometheus-node-exporter stop
   else
     [[ -n "$USER" ]] || {
@@ -64,7 +65,7 @@ configure() {
       return 1
     }
 
-    service prometheus-node-exporter enable
+    systemctl enable prometheus-node-exporter
     service prometheus-node-exporter start
 
     echo "Metric endpoint enabled. You can test it at https://nextcloudpi.local/metrics/system (or under your NC domain under the same path)"

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -18,7 +18,9 @@ install() {
   (
 
   set -e
-  cp /usr/local/etc/ncp-templates/prometheus-node-exporter.defaults /etc/default/prometheus-node-exporter
+  cat > /etc/default/prometheus-node-exporter <<'EOF'
+ARGS="--collector.filesystem.ignored-mount-points=\"^/(dev|proc|run|sys|mnt|var/log|var/lib/docker)($|/)\""
+EOF
   apt-get update && apt-get install -y --no-install-recommends prometheus-node-exporter
 
   # TODO: Docker support?

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -24,6 +24,7 @@ install() {
     service prometheus-node-exporter stop
 
   a2enmod proxy_http
+  service apache2 restart
 
   )
 }

--- a/bin/ncp/SYSTEM/metrics.sh
+++ b/bin/ncp/SYSTEM/metrics.sh
@@ -20,10 +20,11 @@ install() {
   set -e
   cp /usr/local/etc/ncp-templates/prometheus-node-exporter.defaults /etc/default/prometheus-node-exporter
   apt-get update && apt-get install -y --no-install-recommends prometheus-node-exporter
-    service prometheus-node-exporter disable
-    service prometheus-node-exporter stop
 
   a2enmod proxy_http
+
+  service prometheus-node-exporter disable
+  service prometheus-node-exporter stop
   service apache2 restart
 
   )

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -8,10 +8,9 @@
 # More at ownyourbits.com
 #
 
-NCPCFG=${NCPCFG:-/usr/local/etc/ncp.cfg}
-CFGDIR=/usr/local/etc/ncp-config.d
-BINDIR=/usr/local/bin/ncp
-BINDIR=/usr/local/bin/ncp
+export NCPCFG=${NCPCFG:-/usr/local/etc/ncp.cfg}
+export CFGDIR=/usr/local/etc/ncp-config.d
+export BINDIR=/usr/local/bin/ncp
 
 command -v jq &>/dev/null || {
   apt-get update
@@ -110,6 +109,40 @@ function run_app()
   [[ -f "$script" ]] || { echo "file $script not found"; return 1; }
 
   run_app_unsafe "$script"
+}
+
+function find_app_param_num()
+{
+  local script="${1?}"
+  local param_id="${2?}"
+  local ncp_app="$(basename "$script" .sh)"
+  local cfg_file="$CFGDIR/$ncp_app.cfg"
+  [[ -f "$cfg_file" ]] && {
+    local cfg="$( cat "$cfg_file" )"
+    local len="$(jq '.params | length' <<<"$cfg")"
+    for (( i = 0 ; i < len ; i++ )); do
+      local p_id="$(jq -r ".params[$i].id"    <<<"$cfg")"
+      if [[ "${param_id}" == "${p_id}" ]]
+      then
+        echo "$i"
+        return 0
+      fi
+    done
+  }
+
+  return 1
+
+}
+
+find_app_param()
+{
+  local script="${1?}"
+  local param_id="${2?}"
+  local ncp_app="$(basename "$script" .sh)"
+  local cfg_file="$CFGDIR/$ncp_app.cfg"
+
+  p_num="$(find_app_param_num "$script" "$param_id")" || return 1
+  jq -r ".params[$p_num].value" < "$cfg_file"
 }
 
 # receives a script file, no security checks

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -141,7 +141,7 @@ find_app_param()
   local ncp_app="$(basename "$script" .sh)"
   local cfg_file="$CFGDIR/$ncp_app.cfg"
 
-  p_num="$(find_app_param_num "$script" "$param_id")" || return 1
+  local p_num="$(find_app_param_num "$script" "$param_id")" || return 1
   jq -r ".params[$p_num].value" < "$cfg_file"
 }
 

--- a/etc/ncp-config.d/metrics.cfg
+++ b/etc/ncp-config.d/metrics.cfg
@@ -16,7 +16,6 @@
       "id": "USER",
       "name": "Metrics User",
       "value": "metrics",
-      "type": "string",
       "suggest": "metrics"
     },
     {

--- a/etc/ncp-config.d/metrics.cfg
+++ b/etc/ncp-config.d/metrics.cfg
@@ -3,8 +3,8 @@
   "name": "System Metrics, that can be collected by an external server",
   "title": "System Metrics",
   "description": "Prometheus (https://prometheus.io) compatible metrics for things like, CPU/memory/disk usage etc.",
-  "info": "",
-  "infotitle": "",
+  "info": "In order to use these metrics, you will need to setup at least an external Prometheus instance. You can find a quick and easy way to start at https://github.com/theCalcaholic/ncp-monitoring-dashboard",
+  "infotitle": "External service required",
   "params": [
     {
       "id": "ACTIVE",

--- a/etc/ncp-config.d/metrics.cfg
+++ b/etc/ncp-config.d/metrics.cfg
@@ -1,15 +1,15 @@
 {
   "id": "metrics",
-  "name": "System Metrics to be consumed by an external Prometheus instance",
-  "title": "metrics",
-  "description": "TODO",
-  "info": "TODO",
-  "infotitle": "TODO",
+  "name": "System Metrics, that can be collected by an external server",
+  "title": "System Metrics",
+  "description": "Prometheus (https://prometheus.io) compatible metrics for things like, CPU/memory/disk usage etc.",
+  "info": "",
+  "infotitle": "",
   "params": [
     {
       "id": "ACTIVE",
       "name": "Active",
-      "value": "yes",
+      "value": "no",
       "type": "bool"
     },
     {

--- a/etc/ncp-config.d/metrics.cfg
+++ b/etc/ncp-config.d/metrics.cfg
@@ -1,0 +1,29 @@
+{
+  "id": "metrics",
+  "name": "System Metrics to be consumed by an external Prometheus instance",
+  "title": "metrics",
+  "description": "TODO",
+  "info": "TODO",
+  "infotitle": "TODO",
+  "params": [
+    {
+      "id": "ACTIVE",
+      "name": "Active",
+      "value": "yes",
+      "type": "bool"
+    },
+    {
+      "id": "USER",
+      "name": "Metrics User",
+      "value": "metrics",
+      "type": "string",
+      "suggest": "metrics"
+    },
+    {
+      "id": "PASSWORD",
+      "name": "Metrics Password",
+      "value": "",
+      "type": "password"
+    }
+  ]
+}

--- a/etc/ncp-templates/nextcloud.conf.sh
+++ b/etc/ncp-templates/nextcloud.conf.sh
@@ -1,0 +1,79 @@
+#! /bin/bash
+
+set -e
+source /usr/local/etc/library.sh
+source "${BINDIR}/NETWORKING/letsencrypt.sh"
+source "${BINDIR}/SYSTEM/metrics.sh"
+
+echo "### DO NOT EDIT! THIS FILE HAS BEEN AUTOMATICALLY GENERATED. CHANGES WILL BE OVERWRITTEN ###"
+echo ""
+
+cat <<EOF
+<IfModule mod_ssl.c>
+  <VirtualHost _default_:443>
+    DocumentRoot /var/www/nextcloud
+EOF
+
+LETSENCRYPT_DOMAIN="$(tmpl_letsencrypt_domain || true)"
+if [[ "$1" != "--defaults" ]] && [[ -n "$LETSENCRYPT_DOMAIN" ]]
+then
+  echo "    ServerName ${LETSENCRYPT_DOMAIN}"
+  LETSENCRYPT_CERT_BASE_PATH="/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN,,}"
+  LETSENCRYPT_CERT_PATH="${LETSENCRYPT_CERT_BASE_PATH}/fullchain.pem"
+  LETSENCRYPT_KEY_PATH="${LETSENCRYPT_CERT_BASE_PATH}/privkey.pem"
+else
+  unset LETSENCRYPT_DOMAIN
+fi
+
+cat <<EOF
+    CustomLog /var/log/apache2/nc-access.log combined
+    ErrorLog  /var/log/apache2/nc-error.log
+    SSLEngine on
+    SSLCertificateFile      ${LETSENCRYPT_CERT_PATH:-/etc/ssl/certs/ssl-cert-snakeoil.pem}
+    SSLCertificateKeyFile ${LETSENCRYPT_KEY_PATH:-/etc/ssl/private/ssl-cert-snakeoil.key}
+EOF
+
+if [[ "$1" != "--defaults" ]] && tmpl_metrics_enabled
+then
+
+  cat <<EOF
+    SSLProxyEngine on
+
+    <Location /metrics/system>
+      ProxyPass http://localhost:9100/metrics
+
+      Order deny,allow
+      Allow from all
+      AuthType Basic
+      AuthName "Metrics"
+      AuthUserFile /usr/local/etc/metrics.htpasswd
+      <RequireAll>
+        <RequireAny>
+          Require host localhost
+          Require user metrics
+        </RequireAny>
+      </RequireAll>
+
+    </Location>
+EOF
+fi
+
+cat <<EOF
+  </VirtualHost>
+
+  <Directory /var/www/nextcloud/>
+    Options +FollowSymlinks
+    AllowOverride All
+    <IfModule mod_dav.c>
+      Dav off
+    </IfModule>
+    LimitRequestBody 0
+    SSLRenegBufferSize 10486000
+  </Directory>
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
+  </IfModule>
+</IfModule>
+EOF
+
+apache2ctl -t

--- a/etc/ncp-templates/nextcloud.conf.sh
+++ b/etc/ncp-templates/nextcloud.conf.sh
@@ -28,6 +28,8 @@ then
   LETSENCRYPT_CERT_PATH="${LETSENCRYPT_CERT_BASE_PATH}/fullchain.pem"
   LETSENCRYPT_KEY_PATH="${LETSENCRYPT_CERT_BASE_PATH}/privkey.pem"
 else
+  # Make sure the default snakeoil cert exists
+  [ -f /etc/ssl/certs/ssl-cert-snakeoil.pem ] || make-ssl-cert generate-default-snakeoil --force-overwrite
   unset LETSENCRYPT_DOMAIN
 fi
 

--- a/etc/ncp-templates/nextcloud.conf.sh
+++ b/etc/ncp-templates/nextcloud.conf.sh
@@ -20,7 +20,7 @@ cat <<EOF
     DocumentRoot /var/www/nextcloud
 EOF
 
-LETSENCRYPT_DOMAIN="$(tmpl_letsencrypt_domain || true)"
+LETSENCRYPT_DOMAIN="$(tmpl_letsencrypt_domain)"
 if [[ "$1" != "--defaults" ]] && [[ -n "$LETSENCRYPT_DOMAIN" ]]
 then
   echo "    ServerName ${LETSENCRYPT_DOMAIN}"

--- a/etc/ncp-templates/nextcloud.conf.sh
+++ b/etc/ncp-templates/nextcloud.conf.sh
@@ -3,7 +3,13 @@
 set -e
 source /usr/local/etc/library.sh
 source "${BINDIR}/NETWORKING/letsencrypt.sh"
-source "${BINDIR}/SYSTEM/metrics.sh"
+
+if [[ "$DOCKERBUILD" == 1 ]]
+then
+  source "${BINDIR}/SYSTEM/metrics.sh"
+else
+  tmpl_metrics_enabled(){ return 1; }
+fi
 
 echo "### DO NOT EDIT! THIS FILE HAS BEEN AUTOMATICALLY GENERATED. CHANGES WILL BE OVERWRITTEN ###"
 echo ""

--- a/etc/ncp-templates/prometheus-node-exporter.defaults
+++ b/etc/ncp-templates/prometheus-node-exporter.defaults
@@ -1,0 +1,1 @@
+ARGS="--collector.filesystem.ignored-mount-points=\"^/(dev|proc|run|sys|mnt|var/log|var/lib/docker)($|/)\""

--- a/etc/ncp-templates/prometheus-node-exporter.defaults
+++ b/etc/ncp-templates/prometheus-node-exporter.defaults
@@ -1,1 +1,0 @@
-ARGS="--collector.filesystem.ignored-mount-points=\"^/(dev|proc|run|sys|mnt|var/log|var/lib/docker)($|/)\""

--- a/update.sh
+++ b/update.sh
@@ -63,7 +63,7 @@ mkdir -p "$CONFDIR"
 cp -r bin/* /usr/local/bin/
 find etc -maxdepth 1 -type f ! -path etc/ncp.cfg -exec cp '{}' /usr/local/etc \;
 cp -n etc/ncp.cfg /usr/local/etc
-cp -r etc/ncp-templates/* /usr/local/etc/
+cp -r etc/ncp-templates /usr/local/etc/
 
 # install new entries of ncp-config and update others
 for file in etc/ncp-config.d/*; do

--- a/update.sh
+++ b/update.sh
@@ -36,6 +36,7 @@ nc-zram
 SSH
 fail2ban
 NFS
+metrics
 "
 
 # better use a designated container

--- a/update.sh
+++ b/update.sh
@@ -63,6 +63,7 @@ mkdir -p "$CONFDIR"
 cp -r bin/* /usr/local/bin/
 find etc -maxdepth 1 -type f ! -path etc/ncp.cfg -exec cp '{}' /usr/local/etc \;
 cp -n etc/ncp.cfg /usr/local/etc
+cp -r etc/ncp-templates/* /usr/local/etc/
 
 # install new entries of ncp-config and update others
 for file in etc/ncp-config.d/*; do

--- a/updates/1.36.4.sh
+++ b/updates/1.36.4.sh
@@ -4,4 +4,4 @@ set -e
 
 # Required for the reverse proxy of the metrics app
 a2enmod proxy_http
-service apache2 restart
+bash -c "sleep 2 && service apache2 reload" &>/dev/null &

--- a/updates/1.36.4.sh
+++ b/updates/1.36.4.sh
@@ -2,5 +2,6 @@
 
 set -e
 
+# Required for the reverse proxy of the metrics app
 a2enmod proxy_http
 service apache2 restart

--- a/updates/1.36.4.sh
+++ b/updates/1.36.4.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+a2enmod proxy_http
+service apache2 restart


### PR DESCRIPTION
Adds an ncp-app 'metrics' that exposes a prometheus compatible endpoint at https://[nc-domain]:443/metrics/system using [Prometheus Node Exporter](https://prometheus.io/docs/guides/node-exporter/)

- [x] implementation 
- [x] basic testing
- [x] more thorough testing
- [x] Description texts in ncp app
- [ ] usage documentation
- [x] [setup instructions for simple prometheus + nextcloud exporter + grafana instance](https://github.com/theCalcaholic/ncp-monitoring-dashboard)

❌ ~Docker support?~


**EDIT 1**: Probably not going to add docker support for now, since
1. It's not as easy to do as I hoped
2. Many metrics wouldn't work anyways without adjusting container privileges
3. It's not hard to install on the host

## Changes:

```
metrics.{sh,cfg}: Implement ncp-app for prometheus (system) metrics

letsencrypts.sh, nc-nextcloud.sh, nextcloud.conf.sh: Introduce templating/generator concept to allow multiple ncp apps to edit the same file without conflicts

library.sh: Add convenience function find_app_param
```