### PR TITLE
remove unused USER variable from ncp apps nc-notify-updates and nc-update-nc-apps-auto

### DIFF
--- a/etc/ncp-config.d/nc-notify-updates.cfg
+++ b/etc/ncp-config.d/nc-notify-updates.cfg
@@ -11,12 +11,6 @@
       "name": "Active",
       "value": "yes",
       "type": "bool"
-    },
-    {
-      "id": "USER",
-      "name": "User",
-      "value": "ncp",
-      "suggest": "ncp"
     }
   ]
 }

--- a/etc/ncp-config.d/nc-update-nc-apps-auto.cfg
+++ b/etc/ncp-config.d/nc-update-nc-apps-auto.cfg
@@ -11,12 +11,6 @@
       "name": "Active",
       "value": "no",
       "type": "bool"
-    },
-    {
-      "id": "USER",
-      "name": "Notify user",
-      "value": "ncp",
-      "suggest": "ncp"
     }
   ]
 }


### PR DESCRIPTION
remove unused USER variable from ncp apps nc-notify-updates and nc-update-nc-apps-auto