### PR TITLE
Fix nc-https protocol inverted

### DIFF
--- a/bin/ncp/CONFIG/nc-httpsonly.sh
+++ b/bin/ncp/CONFIG/nc-httpsonly.sh
@@ -13,9 +13,9 @@ configure()
 {
   [[ -f /.ncp-image ]] && return 0
   if [[ $ACTIVE == "no" ]]; then
-    local opt=Off proto=https
+    local opt=Off proto=http
     else
-      local opt=On proto=http
+      local opt=On proto=https
   fi
   sed -i "s|RewriteEngine .*|RewriteEngine $opt|" /etc/apache2/sites-available/000-default.conf
   ncc config:system:set overwriteprotocol --value="${proto}"


### PR DESCRIPTION
This change fixes commit 2be666b1f5f43492929bc00872283f6e7ece2443 which caused nc-https logic to be inverted.

Fixes #1351.