### PR TITLE
Update update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -52,8 +52,8 @@ samba
 "
 fi
 
-# check running apt
-pgrep apt &>/dev/null && { echo "apt is currently running. Try again later";  exit 1; }
+# check running apt or apt-get
+pgrep -x "apt|apt-get" &>/dev/null && { echo "apt is currently running. Try again later";  exit 1; }
 
 cp etc/library.sh /usr/local/etc/
 


### PR DESCRIPTION
fix check for running apt during update
(https://github.com/nextcloud/nextcloudpi/issues/1354)

Update script is exiting if any process contains 'apt' in the name. pgrep interpretes <pattern> as regular expression. Whole process name to be checked with option -x.