### PR TITLE
Clarify documentation of nc-previews-auto command

### DIFF
--- a/etc/ncp-config.d/nc-previews-auto.cfg
+++ b/etc/ncp-config.d/nc-previews-auto.cfg
@@ -3,7 +3,7 @@
   "name": "Nc-previews-auto",
   "title": "nc-previews-auto",
   "description": "Periodically generate previews for the gallery",
-  "info": "This will make browsing the gallery much more smooth.\nFor big collections, this can take a LONG time depending on your hardware.\nYou can specify a nightly duration in minutes, or 0",
+  "info": "This will make browsing the gallery much more smooth.\nWhen active, previews will be generated every night at 2am.\nFor big collections, this can take a LONG time depending on your hardware.\nYou can specify a maximum duration in minutes, or 0 for no limit.",
   "infotitle": "",
   "params": [
     {
@@ -14,7 +14,7 @@
     },
     {
       "id": "RUNTIME",
-      "name": "Runtime (in minutes)",
+      "name": "Max. runtime (in minutes)",
       "value": "0",
       "suggest": "0"
     }


### PR DESCRIPTION
At first glance, I thought that "runtime" cloud be used to specify the time when the cron job starts. Had to look at the source code to confirm what the value actually means. Hope this change makes the command easier to understand. :slightly_smiling_face: 