### PR TITLE
Encrypted backups to S3-compatible storage using restic

### DIFF
--- a/bin/ncp/BACKUPS/nc-restic-s3-backup.sh
+++ b/bin/ncp/BACKUPS/nc-restic-s3-backup.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Back up Nextcloud data to S3-compatible storage via restic
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+BASEDIR=/var/www
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y restic
+}
+
+configure()
+{
+  [[ "$S3_BUCKET_URL" == "" ]] && {
+    echo "error: please specify S3 bucket URL"
+    return 1
+  }
+
+  [[ "$S3_KEY_ID" == "" ]] && {
+    echo "error: please specify S3 key ID"
+    return 2
+  }
+
+  [[ "$S3_SECRET_KEY" == "" ]] && {
+    echo "error: please specify S3 secret key"
+    return 3
+  }
+
+  [[ "$RESTIC_PASSWORD" == "" ]] && {
+    echo "error: please specify restic password"
+    return 4
+  }
+
+  save_maintenance_mode || {
+    echo "error: failed to activate Nextcloud maintenance mode"
+    return 5
+  }
+
+  local DATADIR
+  DATADIR=$( sudo -u www-data php /var/www/nextcloud/occ config:system:get datadirectory ) || {
+    echo -e "Error reading data directory. Is NextCloud running and configured?"
+    return 6
+  }
+
+  cd "$DATADIR" || {
+    echo "error: failed to change to data directory $DATADIR"
+    return 7
+  }
+
+  echo "backing up from $DATADIR"
+
+  AWS_ACCESS_KEY_ID="$S3_KEY_ID" AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" RESTIC_PASSWORD="$RESTIC_PASSWORD" restic -r "s3:$S3_BUCKET_URL/ncp-backup" --verbose backup . || {
+    echo "error: restic backup failed"
+    echo "notice: use nc-maintenance to disable maintenance mode anyway if desired"
+    return 8
+  }
+
+  echo "successfully created backup"
+
+  restore_maintenance_mode || {
+    echo "error: failed to disabled Nextcloud maintenance mode"
+    echo "notice: backup has completed anyways"
+    return 8
+  }
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/bin/ncp/BACKUPS/nc-restic-s3-init.sh
+++ b/bin/ncp/BACKUPS/nc-restic-s3-init.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Prepare back up of Nextcloud data to S3-compatible storage via restic
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y restic
+}
+
+configure()
+{
+  [[ "$S3_BUCKET_URL" == "" ]] && {
+    echo "error: please specify S3 bucket URL"
+    return 1
+  }
+
+  [[ "$S3_KEY_ID" == "" ]] && {
+    echo "error: please specify S3 key ID"
+    return 2
+  }
+
+  [[ "$S3_SECRET_KEY" == "" ]] && {
+    echo "error: please specify S3 secret key"
+    return 3
+  }
+
+  [[ "$RESTIC_PASSWORD" == "" ]] && {
+    echo "error: please specify restic password"
+    return 4
+  }
+
+  AWS_ACCESS_KEY_ID="$S3_KEY_ID" AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" RESTIC_PASSWORD="$RESTIC_PASSWORD" restic -r "s3:$S3_BUCKET_URL/ncp-backup" --verbose init || {
+    echo "error: failed to initialize restic repository"
+    return 5
+  }
+
+  echo "successfully initialized repository"
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/bin/ncp/BACKUPS/nc-restic-s3-restore.sh
+++ b/bin/ncp/BACKUPS/nc-restic-s3-restore.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Restore Nextcloud data from S3-compatible storage via restic
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+install()
+{
+  apt-get update
+  apt-get install --no-install-recommends -y restic
+}
+
+configure()
+{
+  [[ "$S3_BUCKET_URL" == "" ]] && {
+    echo "error: please specify S3 bucket URL"
+    return 1
+  }
+
+  [[ "$S3_KEY_ID" == "" ]] && {
+    echo "error: please specify S3 key ID"
+    return 2
+  }
+
+  [[ "$S3_SECRET_KEY" == "" ]] && {
+    echo "error: please specify S3 secret key"
+    return 3
+  }
+
+  [[ "$RESTIC_PASSWORD" == "" ]] && {
+    echo "error: please specify restic password"
+    return 4
+  }
+
+  save_maintenance_mode || {
+    echo "error: failed to activate Nextcloud maintenance mode"
+    return 5
+  }
+
+  local DATADIR
+  DATADIR=$( sudo -u www-data php /var/www/nextcloud/occ config:system:get datadirectory ) || {
+    echo -e "Error reading data directory. Is NextCloud running and configured?"
+    return 6
+  }
+
+  echo "restoring to $DATADIR"
+
+  AWS_ACCESS_KEY_ID="$S3_KEY_ID" AWS_SECRET_ACCESS_KEY="$S3_SECRET_KEY" RESTIC_PASSWORD="$RESTIC_PASSWORD" restic -r "s3:$S3_BUCKET_URL/ncp-backup" --verbose restore latest --target "$DATADIR" || {
+    echo "error: restic restore failed"
+    return 7
+  }
+
+  echo "successfully restored backup"
+
+  restore_maintenance_mode || {
+    echo "error: failed to disabled Nextcloud maintenance mode"
+    echo "notice: backup has been restored anyways"
+    return 8
+  }
+}
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/etc/ncp-config.d/nc-restic-s3-backup.cfg
+++ b/etc/ncp-config.d/nc-restic-s3-backup.cfg
@@ -1,0 +1,32 @@
+{
+  "id": "nc-restic-s3-backup",
+  "name": "nc-restic-s3-backup",
+  "title": "nc-restic-s3-backup",
+  "description": "Back up Nextcloud data to S3-compatible storage via restic",
+  "info": "Note that this backs up only the Nextcloud data directory, not the database.\n\nBefore using this, you may need to prepare a restic repository using nc-restic-s3-init, if you haven't already done so.\n\nPlease enter the S3 bucket access details as well as an encryption password.\nThe password is required to retrieve the data later on!\nNOTE: The password is NOT stored here for security reasons!",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "S3_BUCKET_URL",
+      "name": "S3 bucket URL",
+      "suggest": "https://<host>/<bucket>"
+    },
+    {
+      "id": "S3_KEY_ID",
+      "name": "S3 key ID",
+      "suggest": "S3 key ID"
+    },
+    {
+      "id": "S3_SECRET_KEY",
+      "name": "S3 secret key",
+      "suggest": "S3 secrey key",
+      "type": "password"
+    },
+    {
+      "id": "RESTIC_PASSWORD",
+      "name": "restic password",
+      "suggest": "restic password",
+      "type": "password"
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-restic-s3-init.cfg
+++ b/etc/ncp-config.d/nc-restic-s3-init.cfg
@@ -1,0 +1,32 @@
+{
+  "id": "nc-restic-s3-init",
+  "name": "nc-restic-s3-init",
+  "title": "nc-restic-s3-init",
+  "description": "Prepare back up of Nextcloud data to S3-compatible storage via restic",
+  "info": "Prepare a restic repository for use with nc-restic-s3, if you haven't already done so.\nYou only need to do this once.\n\nPlease enter the S3 bucket access details as well as an encryption password.\nThe password is required to retrieve the data later on!\nNOTE: The password is NOT stored here for security reasons!",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "S3_BUCKET_URL",
+      "name": "S3 bucket URL",
+      "suggest": "https://<host>/<bucket>"
+    },
+    {
+      "id": "S3_KEY_ID",
+      "name": "S3 key ID",
+      "suggest": "S3 key ID"
+    },
+    {
+      "id": "S3_SECRET_KEY",
+      "name": "S3 secret key",
+      "suggest": "S3 secrey key",
+      "type": "password"
+    },
+    {
+      "id": "RESTIC_PASSWORD",
+      "name": "restic password",
+      "suggest": "restic password",
+      "type": "password"
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-restic-s3-restore.cfg
+++ b/etc/ncp-config.d/nc-restic-s3-restore.cfg
@@ -1,0 +1,32 @@
+{
+  "id": "nc-restic-s3-restore",
+  "name": "nc-restic-s3-restore",
+  "title": "nc-restic-s3-restore",
+  "description": "Restore Nextcloud data from S3-compatible storage via restic",
+  "info": "WARNING: This will overwrite existing files in your current Nextcloud data directory with files from latest backup created by nc-restic-s3-backup!\n\nNote that files which already exist in the data directory, but are <strong>not</strong> present in the backup, are <strong>not</strong> deleted.",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "S3_BUCKET_URL",
+      "name": "S3 bucket URL",
+      "suggest": "https://<host>/<bucket>"
+    },
+    {
+      "id": "S3_KEY_ID",
+      "name": "S3 key ID",
+      "suggest": "S3 key ID"
+    },
+    {
+      "id": "S3_SECRET_KEY",
+      "name": "S3 secret key",
+      "suggest": "S3 secrey key",
+      "type": "password"
+    },
+    {
+      "id": "RESTIC_PASSWORD",
+      "name": "restic password",
+      "suggest": "restic password",
+      "type": "password"
+    }
+  ]
+}


### PR DESCRIPTION
This feature allows to create encrypted backups of the Nextcloud data directory to any S3-compatible storage using [restic](https://restic.net/).

Workflow:
 - Create a bucket at the S3 provider of your choice
 - Run nc-restic-s3-init to initialize the encrypted repository (once)
 - Run nc-restic-s3-backup to create a backup when desired (password not stored for security reasons)
 - On a fresh NextCloudPi install, restore the data directory using nc-restic-s3-restore

Limitations:
 - Database is not backed up
 - Backup is created in directory `ncp-backup`. Should this be configurable?
 - Existing files that are not present in the backup are not deleted during restore. If you need a clean state, you must delete the Nextcloud data directory manually. (See also restic/restic#2348)

Notes:
 - You can also [restore specific files](https://restic.readthedocs.io/en/stable/050_restore.html) using `restic restore --include`
 - Use `restic forget --prune` to [remove old backups](https://restic.readthedocs.io/en/stable/060_forget.html) when needed

If you have any suggestions for improving this PR, feel free to comment. :slightly_smiling_face: 