### PR TITLE
Support for encrypted USB drives (LUKS)

### DIFF
--- a/bin/ncp/TOOLS/nc-luks-close.sh
+++ b/bin/ncp/TOOLS/nc-luks-close.sh
@@ -9,6 +9,12 @@
 # More at: https://ownyourbits.com
 #
 
+install()
+{
+  apt-get install -y cryptsetup
+  modprobe dm_mod
+}
+
 configure()
 {
   [[ "$DEV" == "" ]] && {
@@ -43,8 +49,6 @@ configure()
 
   echo "successfully unmounted $DEV"
 }
-
-install() { :; }
 
 # License
 #

--- a/bin/ncp/TOOLS/nc-luks-close.sh
+++ b/bin/ncp/TOOLS/nc-luks-close.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Unmount and close external USB drive encrypted by LUKS
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+configure()
+{
+  [[ "$DEV" == "" ]] && {
+    echo "error: please specify device"
+    return 1
+  }
+
+  if [[ ! -e /media/USBdrive ]]; then
+    echo "notice: /media/USBdrive is not yet mounted -- no need to unmount"
+  else
+    echo "unmounting /media/USBdrive ..."
+
+    umount /media/USBdrive || {
+      echo "unmount failed"
+      return 2
+    }
+  fi
+
+  echo "closing LUKS mapping ..."
+
+  cryptsetup close nc || {
+    echo "cryptsetup close failed"
+    return 3
+  }
+
+  echo "ejecting $DEV ..."
+
+  eject "$DEV" || {
+    echo "eject failed"
+    return 4
+  }
+
+  echo "successfully unmounted $DEV"
+}
+
+install() { :; }
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/bin/ncp/TOOLS/nc-luks-format.sh
+++ b/bin/ncp/TOOLS/nc-luks-format.sh
@@ -9,6 +9,12 @@
 # More at: https://ownyourbits.com
 #
 
+install()
+{
+  apt-get install -y cryptsetup
+  modprobe dm_mod
+}
+
 configure()
 {
   [[ "$DEV" == "" ]] && {
@@ -66,8 +72,6 @@ configure()
 
   echo "notice: consider enabling nc-automount to mount the device if you haven't already done so"
 }
-
-install() { :; }
 
 # License
 #

--- a/bin/ncp/TOOLS/nc-luks-format.sh
+++ b/bin/ncp/TOOLS/nc-luks-format.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Format external USB drive for encryption by LUKS (dangerous)
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+configure()
+{
+  [[ "$DEV" == "" ]] && {
+    echo "error: please specify device"
+    return 1
+  }
+
+  [[ "$DEVICE_LABEL" == "" ]] && {
+    echo "error: please specify device label"
+    return 2
+  }
+
+  [[ "$PARTITION_LABEL" == "" ]] && {
+    echo "error: please specify partition label"
+    return 3
+  }
+
+  [[ "$PASS" == "" ]] && {
+    echo "error: please specify password"
+    return 4
+  }
+
+  [[ ! -b "$DEV" ]] && {
+    echo "error: $DEV is not a block device"
+    return 5
+  }
+
+  if [[ -e /media/USBdrive ]]; then
+    echo "warning: device may be currently mounted"
+    echo "consider deactivating nc-automount or unmounting with nc-luks-close before formatting!"
+  fi
+
+  echo "formatting LUKS device $DEV ..."
+
+  echo -n "$PASS" | cryptsetup luksFormat "$DEV" --label "$DEVICE_LABEL" -d - || {
+    echo "error: cryptsetup format failed"
+    return 6
+  }
+
+  echo "successfully formatted $DEV"
+
+  echo "opening LUKS device $DEV ..."
+
+  echo -n "$PASS" | cryptsetup open --type luks -d - "$DEV" nc || {
+    echo "error: cryptsetup open failed"
+    return 7
+  }
+
+  mkfs.btrfs -q /dev/mapper/nc -f -L "$PARTITION_LABEL" || {
+   echo "error: mkfs.btrfs failed"
+    return 8
+  }
+
+  echo "BTRFS file system successfully created on $DEV"
+
+  echo "notice: consider enabling nc-automount to mount the device if you haven't already done so"
+}
+
+install() { :; }
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/bin/ncp/TOOLS/nc-luks-open.sh
+++ b/bin/ncp/TOOLS/nc-luks-open.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Mount external USB drive encrypted by LUKS
+#
+# Copyleft 2021 by Thomas Heller
+# Copyleft 2017 by Ignacio Nunez Hernanz <nacho _a_t_ ownyourbits _d_o_t_ com>
+# GPL licensed (see end of file) * Use at your own risk!
+#
+# More at: https://ownyourbits.com
+#
+
+configure()
+{
+  [[ -e /dev/mapper/nc ]] && {
+    echo "encrypted device is already opened"
+    return 0
+  }
+
+  [[ "$DEV" == "" ]] && {
+    echo "error: please specify device"
+    return 1
+  }
+
+  [[ "$PASS" == "" ]] && {
+    echo "error: please specify password"
+    return 2
+  }
+
+  [[ ! -b "$DEV" ]] && {
+    echo "error: $DEV is not a block device"
+    return 3
+  }
+
+  echo "opening LUKS device $DEV ..."
+
+  echo -n "$PASS" | cryptsetup open --type luks -d - "$DEV" nc || {
+    echo "error: cryptsetup open failed"
+    return 4
+  }
+
+  echo "successfully opened $DEV"
+}
+
+install() { :; }
+
+# License
+#
+# This script is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This script is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this script; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+# Boston, MA  02111-1307  USA

--- a/bin/ncp/TOOLS/nc-luks-open.sh
+++ b/bin/ncp/TOOLS/nc-luks-open.sh
@@ -9,6 +9,12 @@
 # More at: https://ownyourbits.com
 #
 
+install()
+{
+  apt-get install -y cryptsetup
+  modprobe dm_mod
+}
+
 configure()
 {
   [[ -e /dev/mapper/nc ]] && {
@@ -40,8 +46,6 @@ configure()
 
   echo "successfully opened $DEV"
 }
-
-install() { :; }
 
 # License
 #

--- a/build/build-SD-rpi.sh
+++ b/build/build-SD-rpi.sh
@@ -72,6 +72,11 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     apt-get install -y --no-install-recommends haveged
     systemctl enable haveged.service
 
+    # install cryptsetup for LUKS support
+    # depmod seems to be broken on Raspbian?
+    # reboot is required to load the required dm_mod kernel module
+    apt-get install -y cryptsetup
+
     # harden SSH further for Raspbian
     sed -i 's|^#PermitRootLogin .*|PermitRootLogin no|' /etc/ssh/sshd_config
 

--- a/build/build-SD-rpi.sh
+++ b/build/build-SD-rpi.sh
@@ -72,11 +72,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     apt-get install -y --no-install-recommends haveged
     systemctl enable haveged.service
 
-    # install cryptsetup for LUKS support
-    # depmod seems to be broken on Raspbian?
-    # reboot is required to load the required dm_mod kernel module
-    apt-get install -y cryptsetup
-
     # harden SSH further for Raspbian
     sed -i 's|^#PermitRootLogin .*|PermitRootLogin no|' /etc/ssh/sshd_config
 

--- a/etc/ncp-config.d/nc-luks-close.cfg
+++ b/etc/ncp-config.d/nc-luks-close.cfg
@@ -1,0 +1,17 @@
+{
+  "id": "nc-luks-close",
+  "name": "nc-luks-close",
+  "title": "nc-luks-close",
+  "description": "Unmount and close external USB drive encrypted by LUKS",
+  "info": "Note that if you moved the Nextcloud database to the USB drive using nc-database, you need to move it back to the default location or stop the database service manually before you can unmount the USB drive.",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "DEV",
+      "name": "Device",
+      "value": "/dev/sda1",
+      "suggest": "/dev/sda1",
+      "type": "file"
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-luks-format.cfg
+++ b/etc/ncp-config.d/nc-luks-format.cfg
@@ -1,0 +1,35 @@
+{
+  "id": "nc-luks-format",
+  "name": "nc-luks-format",
+  "title": "nc-luks-format",
+  "description": "Format external USB drive for encryption by LUKS (dangerous)",
+  "info": "Make sure that ONLY the USB drive that you want to format is plugged in.\ncareful, this will destroy any data in the USB drive\n\n** YOU WILL LOSE ALL YOUR USB DATA **\n\nThe password is required to retrieve the data later on!\nNOTE: The password is NOT stored here for security reasons!",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "DEV",
+      "name": "Device",
+      "value": "/dev/sda1",
+      "suggest": "/dev/sda1",
+      "type": "file"
+    },
+    {
+      "id": "DEVICE_LABEL",
+      "name": "Device label",
+      "value": "myCloudDrive",
+      "suggest": "myCloudDrive"
+    },
+    {
+      "id": "PARTITION_LABEL",
+      "name": "Partition label",
+      "value": "myCloudDrive",
+      "suggest": "myCloudDrive"
+    },
+    {
+      "id": "PASS",
+      "name": "Password",
+      "suggest": "LUKS password",
+      "type": "password"
+    }
+  ]
+}

--- a/etc/ncp-config.d/nc-luks-open.cfg
+++ b/etc/ncp-config.d/nc-luks-open.cfg
@@ -1,0 +1,23 @@
+{
+  "id": "nc-luks-open",
+  "name": "nc-luks-open",
+  "title": "nc-luks-open",
+  "description": "Mount external USB drive encrypted by LUKS",
+  "info": "Note that this step needs to be repeated after every reboot.\nThe password is NOT stored for security reasons.",
+  "infotitle": "",
+  "params": [
+    {
+      "id": "DEV",
+      "name": "Device",
+      "value": "/dev/sda1",
+      "suggest": "/dev/sda1",
+      "type": "file"
+    },
+    {
+      "id": "PASS",
+      "name": "Password",
+      "suggest": "LUKS password",
+      "type": "password"
+    }
+  ]
+}


### PR DESCRIPTION
This feature allows to format an external USB drive using `cryptsetup` for LUKS encryption, to store Nextcloud data directory and Nextcloud database securely.

Workflow:
 - Format attached USB drive using nc-luks-format (if it's not already a LUKS-encrypted drive)
 - Open the encrypted container using nc-luks-open (password not stored for security reasons)
 - Enable nc-automount to mount the LUKS partition
 - Move Nextcloud data directory to USB drive using nc-datadir
 - Move Nextcloud database to USB drive using nc-database (optional)
 - Optionally, if you need to detach the USB drive without shutting down the system, use nc-luks-close

Limitations:
 - nc-luks-close cannot unmount the LUKS partition automatically if the Nextcloud database is stored there (You need to move the database back to the original unencrypted location or stop the database server manually)
 - nc-luks-format is not included in the setup wizard

Notes:
 - After rebooting, you need to run nc-luks-open again, because the password is not stored for security reasons. (Until then, you will see the following error message in the Nextcloud frontend: "**Error** Your data directory is invalid Ensure there is a file called `.ocdata` in the root of the data directory." or "Internal Server Error" if you also moved the database to the encrypted drive)

If you have any suggestions for improving this PR, feel free to comment. :slightly_smiling_face: 