### PR TITLE
notify_push: fix service not restarting on binary update

### DIFF
--- a/updates/1.46.0.sh
+++ b/updates/1.46.0.sh
@@ -1,0 +1,43 @@
+
+# docker images only
+[[ -f /.docker-image ]] && {
+  cat <<EOF > /etc/cron.daily
+#!/usr/bin/env bash
+. /usr/local/etc/library.sh
+ncc notify_push:self-test || {
+  killall notify_push
+  sleep 1
+  start_notify_push
+}"
+EOF
+}
+
+# for non docker images
+[[ ! -f /.docker-image ]] && {
+  cat > /etc/systemd/system/refresh_notify_push.service <<EOF
+[Unit]
+Description = Restart notify_push service when the NC app is updated
+
+[Service]
+Type = oneshot
+ExecStart = systemctl restart notify_push.service
+
+[Install]
+WantedBy = multi-user.target
+EOF
+  cat > /etc/systemd/system/refresh_notify_push.path <<EOF
+[Unit]
+Description = Path watcher component for refresh_notify_push.service
+
+[Path]
+PathModified = /var/www/nextcloud/apps/notify_push/
+
+[Install]
+WantedBy = multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable refresh_notify_push.{path,service}
+  systemctl enable notify_push.service
+  systemctl restart refresh_notify_push.path
+}

--- a/updates/1.46.0.sh
+++ b/updates/1.46.0.sh
@@ -1,7 +1,7 @@
 
 # docker images only
 [[ -f /.docker-image ]] && {
-  cat <<EOF > /etc/cron.daily
+  cat <<EOF > /etc/cron.daily/refresh_notify_push
 #!/usr/bin/env bash
 . /usr/local/etc/library.sh
 ncc notify_push:self-test || {
@@ -10,6 +10,7 @@ ncc notify_push:self-test || {
   start_notify_push
 }"
 EOF
+  chmod +x /etc/cron.daily/refresh_notify_push
 }
 
 # for non docker images

--- a/updates/1.46.0.sh
+++ b/updates/1.46.0.sh
@@ -39,6 +39,5 @@ EOF
 
   systemctl daemon-reload
   systemctl enable refresh_notify_push.{path,service}
-  systemctl enable notify_push.service
   systemctl restart refresh_notify_push.path
 }


### PR DESCRIPTION
Fixes #1397 

I've opted to systemd path monitoring for non-docker versions, as that is fit better for the job (will fix the situation quicker and not restart constantly if there is another issue with notify_push).

For the latter reason, I've also set up the cron job for the docker version to run just daily and not more frequent.

From my perspective, this can be merged. @nachoparker do you have any objections?