### PR TITLE
Prevent backup restoration if datadir within ncdir (#1400)

### DIFF
--- a/bin/ncp/BACKUPS/nc-restore.sh
+++ b/bin/ncp/BACKUPS/nc-restore.sh
@@ -67,7 +67,7 @@ else
 fi
 [[ "$DATADIR" == "" ]] && { echo "Error reading data directory"; exit 1; }
 
-datadir_in_ncdir=$(find "${NCDIR}" -type d -name "${DATADIR}")
+datadir_in_ncdir=$(find "${NCDIR}" -type d -wholename "${DATADIR}")
 [[ -n datadir_in_ncdir ]] && { echo "Datadir ${DATADIR} is contained within ncdir ${NCDIR}. Please manually move or remove datadir from within ncdir prior to backup restoration."; exit 1; }
 
 ## RESTORE FILES


### PR DESCRIPTION
Follow up to #1400, this is a quick changeset that attempts to fix the bug described there.

Perhaps it would be better in general to try to move the datadir somewhere else if this ever happens. Given that there is already similar logic elsewhere in the script that I'd prefer not to try to coordinate with (since they'd need to know where it gets moved to), this seems like a reasonable way of making script execution quite a bit safer at the cost of being slightly more inconvenient for people who were already planning to replace their datadir.