### PR TITLE
fix update from pre-1.46 to post-1.46 not working in docker

### DIFF
--- a/updates/1.46.0.sh
+++ b/updates/1.46.0.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+set -e
 
 # docker images only
 [[ -f /.docker-image ]] && {
@@ -8,7 +11,7 @@ ncc notify_push:self-test || {
   killall notify_push
   sleep 1
   start_notify_push
-}"
+}
 EOF
   chmod +x /etc/cron.daily/refresh_notify_push
 }
@@ -41,3 +44,6 @@ EOF
   systemctl enable refresh_notify_push.{path,service}
   systemctl restart refresh_notify_push.path
 }
+
+
+exit 0


### PR DESCRIPTION
The script previously used `[[ ! -f /.docker-image ]] && { ... }` as its last statement, which returns non-zero in docker (as it should), but this exit code is then used as the over-all exit code of the update script, thus failing the update whenever used in docker container. Fixed by adding the same `exit 0` that's already there in all other update-scripts. Fixes issue #1405

Also removed a quote that I'm _pretty_ sure shouldn't be there.