### PR TITLE
Update ncp-dist-upgrade

### DIFF
--- a/bin/ncp-dist-upgrade
+++ b/bin/ncp-dist-upgrade
@@ -50,6 +50,9 @@ sed -i 's/stretch/buster/g' /etc/apt/sources.list
 sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/*
 rm -f /etc/apt/sources.list.d/php.list
 
+# Changes the necessary line for DHCP to work after a reboot https://forums.raspberrypi.com/viewtopic.php?t=320383
+sed -i 's/ExecStart=/usr/lib/dhcpcd5/dhcpcd -q -w/ExecStart=/usr/sbin/dhcpcd -q -w/g' /etc/systemd/system/dhcpcd.service.d/wait.conf
+
 # install latest distro
 apt-get update
 apt-get dist-upgrade -y


### PR DESCRIPTION
Added a sed -i statement that changes the necessary line in /etc/systemd/system/dhcpcd.service.d/wait.conf so DHCP works after a reboot.
This is a fix for raspbian OS, the DHCP works just fine one the raspi debian image, when building though you need to copy the /etc/resolv.conf & /etc/hosts over

Signed-off-by: ZendaiOwl <victorray91@pm.me>