### PR TITLE
Allow NextCloudPi to run/update on Linux Deploy containers in Android

### DIFF
--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -87,8 +87,15 @@ echo "port check 80|$( is_port_open 80 )"
 echo "port check 443|$( is_port_open 443 )"
 
 # LAN
-IFACE=$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )
-GW=$(    ip r | grep "default via" | awk '{ print $3 }' | head -1 )
+ if [ ! -e /usr/sbin/unchroot ]; then
+    ## Standard Install
+    IFACE=$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )
+    GW=$(    ip r | grep "default via" | awk '{ print $3 }' | head -1 )
+ else
+    ## Android Container
+    IFACE=$( ip r | awk '{ print $3 }' | head -1 )
+    GW=$( ip r get 9.9.9.9 | grep "via" | awk '{ print $3 }' | head -1 )
+ fi
 IP="$(get_ip)"
 
 echo "IP|$IP"

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -417,9 +417,15 @@ function nc_version()
 
 function get_ip()
 {
-  local iface
-  iface="$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )"
-  ip a show dev "$iface" | grep global | grep -oP '\d{1,3}(.\d{1,3}){3}' | head -1
+ if [ ! -e /usr/sbin/unchroot ]; then 
+    ## Standard Install
+    local iface
+    iface="$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )"
+    ip a show dev "$iface" | grep global | grep -oP '\d{1,3}(.\d{1,3}){3}' | head -1
+ else
+    ## Android Container
+    (ip -o route get to 9.9.9.9 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+ fi    
 }
 
 function is_an_ip()

--- a/lamp.sh
+++ b/lamp.sh
@@ -34,11 +34,9 @@ install()
 
     mkdir -p /run/php
 
-    ##  Android containers need to explicitly set Mutex file 
-    if [ ! -e /usr/sbin/unchroot ]; then
-      echo "Mutex file:${APACHE_LOCK_DIR} default" >> /etc/apache2/apache2.conf
-    fi
-
+    ## Android container needs to explicitly set this Apache default 
+    [ -e /usr/sbin/unchroot ] && sed -i 's/#Mutex file:${APACHE_LOCK_DIR} default/Mutex file:${APACHE_LOCK_DIR} default/g' /etc/apache2/apache2.conf 
+    
     # mariaDB password
     local DBPASSWD="default"
     echo -e "[client]\npassword=$DBPASSWD" > /root/.my.cnf

--- a/lamp.sh
+++ b/lamp.sh
@@ -34,6 +34,11 @@ install()
 
     mkdir -p /run/php
 
+    ##  Android containers need to explicitly set Mutex file 
+    if [ ! -e /usr/sbin/unchroot ]; then
+      echo "Mutex file:${APACHE_LOCK_DIR} default" >> /etc/apache2/apache2.conf
+    fi
+
     # mariaDB password
     local DBPASSWD="default"
     echo -e "[client]\npassword=$DBPASSWD" > /root/.my.cnf


### PR DESCRIPTION
Hello, 

Turns out that NextCloudPi runs very nicely on Android in a  Linux Deploy container.   The changes in this PR are the minimim needed to accmodate running in Linux Deploy.  There are other things needed like SysV initscripts, but that can be fixed externally.  

If these changes can be accomodated NextCloudPi will update on Android like all other supported devices,  and a fork won't be necessary to prevent breakage from updates.    

- [Video](https://www.youtube.com/watch?v=RuHJ_S9DcG4) of the deployment at work
- Linux Deploy image: [ncd12.tgz](https://github.com/DesktopECHO/linuxdeploy-images)

Cheers,
D.