### PR TITLE
Fix 32/64 bit architecture detection

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -194,8 +194,8 @@ else
     apachectl -k graceful
     ## make sure the notify_push daemon is runnnig
 
-    arch="$(uname -m)"
-    [[ "${arch}" =~ "armv7" ]] && arch="armv7"
+    arch="$(dpkg --print-architecture)"
+    [[ "${arch}" = "armhf" ]] && arch="armv7"
     cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -195,7 +195,7 @@ else
     ## make sure the notify_push daemon is runnnig
 
     arch="$(dpkg --print-architecture)"
-    [[ "${arch}" = "armhf" ]] && arch="armv7"
+    [[ "$(uname -m)" =~ "armv7" ]] || [[ "${arch}" == "armhf" ]] && arch="armv7"
     cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -195,7 +195,7 @@ else
     ## make sure the notify_push daemon is runnnig
 
     arch="$(dpkg --print-architecture)"
-    [[ "$(uname -m)" =~ "armv7" ]] || [[ "${arch}" == "armhf" ]] && arch="armv7"
+    [[ "${arch}" =~ ^(armhf|arm)$ ]] && arch="armv7"
     cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients

--- a/bin/ncp/CONFIG/nc-init.sh
+++ b/bin/ncp/CONFIG/nc-init.sh
@@ -152,7 +152,7 @@ EOF
   ncc app:disable updatenotification
 
   # News dropped support for 32-bit -> https://github.com/nextcloud/news/issues/1423
-  if ! [[ "$(uname -m)" =~ "armv7" ]]; then
+  if ! [[ "$(dpkg --print-architecture)" = "armhf" ]]; then
     ncc app:install news
     ncc app:enable  news
   fi

--- a/bin/ncp/CONFIG/nc-init.sh
+++ b/bin/ncp/CONFIG/nc-init.sh
@@ -152,7 +152,7 @@ EOF
   ncc app:disable updatenotification
 
   # News dropped support for 32-bit -> https://github.com/nextcloud/news/issues/1423
-  if ! [[ "$(dpkg --print-architecture)" = "armhf" ]]; then
+  if [[ "$(dpkg --print-architecture)" != "armhf" ]] || [[ ! "$(uname -m)" =~ "armv7" ]]; then
     ncc app:install news
     ncc app:enable  news
   fi

--- a/bin/ncp/CONFIG/nc-init.sh
+++ b/bin/ncp/CONFIG/nc-init.sh
@@ -152,7 +152,7 @@ EOF
   ncc app:disable updatenotification
 
   # News dropped support for 32-bit -> https://github.com/nextcloud/news/issues/1423
-  if [[ "$(dpkg --print-architecture)" != "armhf" ]] || [[ ! "$(uname -m)" =~ "armv7" ]]; then
+  if ! [[ "$(dpkg --print-architecture)" =~ ^(armhf|arm)$ ]]; then
     ncc app:install news
     ncc app:enable  news
   fi

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -165,7 +165,7 @@ function start_notify_push
     if [[ -f /.docker-image ]]; then
       local arch
       arch="$(dpkg --print-architecture)"
-      [[ "${arch}" = "armhf" ]] && arch="armv7"
+      [[ "${arch}" == "armhf" ]] || [[ "$(uname -m)" =~ "armv7" ]] && arch="armv7"
       NEXTCLOUD_URL=https://localhost sudo -E -u www-data /var/www/nextcloud/apps/notify_push/bin/"${arch}"/notify_push --allow-self-signed /var/www/nextcloud/config/config.php &>/dev/null &
     else
       systemctl enable --now notify_push

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -165,7 +165,7 @@ function start_notify_push
     if [[ -f /.docker-image ]]; then
       local arch
       arch="$(dpkg --print-architecture)"
-      [[ "${arch}" == "armhf" ]] || [[ "$(uname -m)" =~ "armv7" ]] && arch="armv7"
+      [[ "${arch}" =~ ^(armhf|arm)$ ]] && arch="armv7"
       NEXTCLOUD_URL=https://localhost sudo -E -u www-data /var/www/nextcloud/apps/notify_push/bin/"${arch}"/notify_push --allow-self-signed /var/www/nextcloud/config/config.php &>/dev/null &
     else
       systemctl enable --now notify_push

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -164,8 +164,8 @@ function start_notify_push
     pgrep notify_push &>/dev/null && return
     if [[ -f /.docker-image ]]; then
       local arch
-      arch="$(uname -m)"
-      [[ "${arch}" =~ "armv7" ]] && arch="armv7"
+      arch="$(dpkg --print-architecture)"
+      [[ "${arch}" = "armhf" ]] && arch="armv7"
       NEXTCLOUD_URL=https://localhost sudo -E -u www-data /var/www/nextcloud/apps/notify_push/bin/"${arch}"/notify_push --allow-self-signed /var/www/nextcloud/config/config.php &>/dev/null &
     else
       systemctl enable --now notify_push

--- a/updates/1.43.0.sh
+++ b/updates/1.43.0.sh
@@ -35,8 +35,8 @@ install_app nc-restore
 [[ ! -f /.docker-image ]] && {
 
   # fix HPB with dynamic public IP
-  arch="$(uname -m)"
-  [[ "${arch}" =~ "armv7" ]] && arch="armv7"
+  arch="$(dpkg --print-architecture)"
+  [[ "${arch}" = "armhf" ]] && arch="armv7"
   cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients

--- a/updates/1.43.0.sh
+++ b/updates/1.43.0.sh
@@ -36,7 +36,7 @@ install_app nc-restore
 
   # fix HPB with dynamic public IP
   arch="$(dpkg --print-architecture)"
-  [[ "${arch}" = "armhf" ]] && arch="armv7"
+  [[ "${arch}" == "armhf" ]] || [[ "$(uname -m)" =~ "armv7" ]] && arch="armv7"
   cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients

--- a/updates/1.43.0.sh
+++ b/updates/1.43.0.sh
@@ -36,7 +36,7 @@ install_app nc-restore
 
   # fix HPB with dynamic public IP
   arch="$(dpkg --print-architecture)"
-  [[ "${arch}" == "armhf" ]] || [[ "$(uname -m)" =~ "armv7" ]] && arch="armv7"
+  [[ "${arch}" =~ ^(armhf|arm)$ ]] && arch="armv7"
   cat > /etc/systemd/system/notify_push.service <<EOF
 [Unit]
 Description = Push daemon for Nextcloud clients


### PR DESCRIPTION
To determine if the Debian edition hosting NextCloud is 32 or 64 bit, NCP uses ``uname -m``.  This is mostly fine until you have (for example) a kernel reporting ``aarch64`` that is running Debian ``armhf`` in a container, whereupon the wheels fall off and scripts break.

As opposed to asking the Kernel, it's more reliable to ask the distro if NextCloud is 32 (armv7l, armv8l) or 64 (aarch64) bit to account for all possible hardware setups.
