### PR TITLE
Adding installation with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ sudo ncp-config
 ![NCP-config](https://ownyourbits.com/wp-content/uploads/2017/03/ncp-conf-700x456.jpg)
 
 
-## Run in docker
+## Run in Docker
 
 ```
 docker run -d -p 4443:4443 -p 443:443 -p 80:80 -v ncdata:/data --name nextcloudpi ownyourbits/nextcloudpi $DOMAIN
@@ -100,6 +100,22 @@ docker run -d -p 4443:4443 -p 443:443 -p 80:80 -v ncdata:/data --name nextcloudp
 ```
 lxc import NextCloudPi_LXD_09-29-21.tar.bz
 lxc start ncp
+```
+
+## Run with Docker Compose
+
+```
+  version: '3'
+  nextcloudpi:
+    restart: always
+    container_name: nextcloudpi
+    image: ownyourbits/nextcloudpi
+    ports:
+      - "443:443"   # nextcloud https
+      - "80:80"     # nextcloud http, can be disabled for security reasons
+      - "4443:4443" # nextcloudpi web ui
+    volumes:
+    - ncdata:/data
 ```
 
 ## How to build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+  nextcloudpi:
+    restart: always
+    container_name: nextcloudpi
+    image: ownyourbits/nextcloudpi
+    ports:
+      - "443:443"   # nextcloud https
+      - "80:80"     # nextcloud http, can be disabled for security reasons
+      - "4443:4443" # nextcloudpi web ui
+    volumes:
+    - ncdata:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+  version: '3'
   nextcloudpi:
     restart: always
     container_name: nextcloudpi


### PR DESCRIPTION
Very simple edit adding docker-compose functionality. Using docker-compose instead of pure docker is generally preferred, because it is:
a. More beginner friendly, as any mistakes can be corrected and updated by simply changing the compose file
b. Better suited for advanced users, looking to add more functionality to their containers

This commit adds the following:
1. docker-compose.yml: a barebones docker-compose script ready for usage. I've made this script directly from the regular docker command in the README and confirmed it worked by creating an entirely new stack/container and by migrating a non-compose docker based install.
2. The same docker-compose script has been added to the README in the `install` section. This change should speak for itself.
3. Capitalization change from `Run in docker` to `Run in Docker`: As LXD has also been capitalized, Docker should be too.  _Very_ minor change.

Please note that the environment variable, `$DOMAIN`, has not been added to the compose script. There's currently no indicator of its usage in the regular docker script and its usage is not necessary. If it is needed, [adding it to the compose script is trivial.](https://docs.docker.com/compose/environment-variables/) In that case I'd also suggest adding an install step to the non-compose option, showing new users to set this variable in their terminal beforehand.