### PR TITLE
Fix/ncp diag

### DIFF
--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -66,25 +66,67 @@ echo "internet check|$( ping -W 2 -w 1 -q github.com &>/dev/null && echo ok || e
 
 function is_port_open()
 {
-  local port=$1
-  local public_ip
-  public_ip="$(curl -m4 -4 https://icanhazip.com 2>/dev/null)" || { echo "closed"; return 1; }
-  if [[ "${public_ip}" == "" ]]; then
-    public_ip="$(curl -m4 -6 https://icanhazip.com 2>/dev/null)" || { echo "closed"; return 1; }
-  fi
-  local tmp_file=$(mktemp)
-  local token=$(wget -T2 -t1 -qO- --keep-session-cookies --save-cookies $tmp_file https://portchecker.co | grep -oP "_csrf\" value=\"\K.*\"")
+  local port="$1" public_ipv4 public_ipv6 tmp_file token ipv4_check ipv4_port ipv6_check ipv6_port
+  ipv4_check=""
+  ipv4_port=""
+  ipv6_check=""
+  ipv6_port=""
 
-  if [[ "${token}" != "" ]]; then
-    wget -T2 -t1 -qO- --load-cookies $tmp_file https://portchecker.co/check --post-data "target_ip=${public_ip}&port=${port}&_csrf=${token::-1}" \
-    | grep -q '<span class="green">open</span>' && { echo "open"; return 1; }
+  public_ipv4="$(curl -s -m4 -4 https://icanhazip.com 2>/dev/null)" || { ipv4_check="1"; }
+  public_ipv6="$(curl -s -m4 -6 https://icanhazip.com 2>/dev/null)" || { ipv6_check="1"; }
+
+  if [[ "$ipv4_check" == "1" ]] && [[ "$ipv6_check" == "1" ]]
+  then
+    echo "Error - IPv4 & IPv6: N/A, couldn't get external IP."; return 1;
   fi
-  rm $tmp_file
-  echo "closed"
+
+  tmp_file=$(mktemp)
+  token=$(wget -T2 -t1 -qO- --keep-session-cookies --save-cookies $tmp_file https://portchecker.co | grep -oP "_csrf\" value=\"\K.*\"")
+
+  if [[ "${token}" != "" ]]
+  then
+    if [[ "$ipv4_check" != "1" ]] && [[ "$ipv6_check" == "1" ]]
+    then
+      wget -T2 -t1 -qO- --load-cookies $tmp_file https://portchecker.co/check \
+      --post-data "target_ip=${public_ipv4}&port=${port}&_csrf=${token::-1}" | grep -q '<span class="green">open</span>' && \
+      { echo "open IPv4 (IPv6: N/A)"; return 1; } || { echo "closed IPv4 (IPv6: N/A)"; return 1; }
+    elif [[ "$ipv4_check" == "1" ]] && [[ "$ipv6_check" != "1" ]]
+    then
+      wget -T2 -t1 -qO- --load-cookies $tmp_file https://portchecker.co/check \
+      --post-data "target_ip=${public_ipv6}&port=${port}&_csrf=${token::-1}" | grep -q '<span class="green">open</span>' && \
+      { echo "open IPv6 (IPv4: N/A)"; return 1; } || { echo "closed IPv6 (IPv4: N/A)"; return 1; }
+    else
+      wget -T2 -t1 -qO- --load-cookies $tmp_file https://portchecker.co/check \
+      --post-data "target_ip=${public_ipv4}&port=${port}&_csrf=${token::-1}" | grep -q '<span class="green">open</span>' && \
+      { ipv4_port="open"; } || { ipv4_port="closed"; }
+
+      wget -T2 -t1 -qO- --load-cookies $tmp_file https://portchecker.co/check \
+      --post-data "target_ip=${public_ipv6}&port=${port}&_csrf=${token::-1}" | grep -q '<span class="green">open</span>' && \
+      { ipv6_port="open"; } || { ipv6_port="closed"; }
+
+      if [[ "$ipv4_port" == "open" ]] && [[ "$ipv6_port" == "open" ]]
+      then
+        echo "open IPv4 & IPv6"; return 1;
+      fi
+
+      if [[ "$ipv4_port" == "open" ]] && [[ "$ipv6_port" == "closed" ]]
+      then
+        echo "open IPv4 (IPv6: closed)"; return 1;
+      elif [[ "$ipv4_port" == "closed" ]] && [[ "$ipv6_port" == "open" ]]
+      then
+        echo "open IPv6 (IPv4: closed)"; return 1;
+      else
+        echo "closed IPv4 & IPv6"; return 1;
+      fi
+    fi
+  else
+    echo "Error - Couldn't obtain a token for port check"; return 1;
+  fi
+  rm "$tmp_file"
 }
 
-echo "port check 80|$( is_port_open 80 )"
-echo "port check 443|$( is_port_open 443 )"
+echo "port check 80 | $( is_port_open 80 )"
+echo "port check 443 | $( is_port_open 443 )"
 
 # LAN
 IFACE=$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )

--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -66,7 +66,8 @@ echo "internet check|$( ping -W 2 -w 1 -q github.com &>/dev/null && echo ok || e
 
 function is_port_open()
 {
-  local port="$1" public_ipv4 public_ipv6 tmp_file token ipv4_check ipv4_port ipv6_check ipv6_port
+  local port public_ipv4 public_ipv6 tmp_file token ipv4_check ipv4_port ipv6_check ipv6_port
+  port="$1"
   ipv4_check=""
   ipv4_port=""
   ipv6_check=""
@@ -125,8 +126,8 @@ function is_port_open()
   rm "$tmp_file"
 }
 
-echo "port check 80 | $( is_port_open 80 )"
-echo "port check 443 | $( is_port_open 443 )"
+echo "port check 80|$( is_port_open 80 )"
+echo "port check 443|$( is_port_open 443 )"
 
 # LAN
 IFACE=$( ip r | grep "default via" | awk '{ print $5 }' | head -1 )

--- a/build/build-docker.sh
+++ b/build/build-docker.sh
@@ -56,7 +56,13 @@ clean_workspace() {
     build_arch "$target" "${release}" "${arch_args[@]}"
   done
 
+  set +e
   exit 0
+}
+[[ "${BASH_SOURCE[0]}" != "$0" ]] && {
+	echo "Script has been sourced, aborting."
+	set +e
+	exit 1
 }
 
 # License

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -3,7 +3,9 @@ ARG arch_qemu=arm
 ARG release=bullseye
 FROM debian:${release}-slim AS qemu
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive \
+	apt-get install -y --no-install-recommends qemu-user-static
 
 FROM ${arch}/debian:${release}-slim as debian-ncp
 

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,8 +1,14 @@
-version: '3'
+version: "3.3"
+
+volumes:
+  ncdata:
+    external: false
+
 services:
   nextcloudpi:
-    image: ownyourbits/nextcloudpi-x86
-    command: "${IP}"
+    image: 'ownyourbits/nextcloudpi:latest'
+    restart: unless-stopped
+    container_name: nextcloudpi
     ports:
      - "80:80"
      - "443:443"
@@ -10,13 +16,11 @@ services:
     volumes:
      - ncdata:/data
      - /etc/localtime:/etc/localtime:ro
+     - /var/run/docker.sock:/var/run/docker.sock:ro
     # for nc-encrypt
     devices:
       - /dev/fuse:/dev/fuse
     # for nc-encrypt # NOTE: take a look at this https://github.com/docker/for-linux/issues/321#issuecomment-677744121
     cap_add:
       - SYS_ADMIN
-    container_name: nextcloudpi
-
-volumes:
-  ncdata:
+    # command: "${IP}"

--- a/lamp.sh
+++ b/lamp.sh
@@ -39,8 +39,8 @@ install()
     echo -e "[client]\npassword=$DBPASSWD" > /root/.my.cnf
     chmod 600 /root/.my.cnf
 
-    debconf-set-selections <<< "mariadb-server-5.5 mysql-server/root_password password $DBPASSWD"
-    debconf-set-selections <<< "mariadb-server-5.5 mysql-server/root_password_again password $DBPASSWD"
+    debconf-set-selections <<< "mariadb-server-10.5 mysql-server/root_password password $DBPASSWD"
+    debconf-set-selections <<< "mariadb-server-10.5 mysql-server/root_password_again password $DBPASSWD"
     $APTINSTALL mariadb-server php${PHPVER}-mysql
     mkdir -p /run/mysqld
     chown mysql /run/mysqld


### PR DESCRIPTION
I've rewritten `is_port_open` function in `ncp-diag` to now check for open ports on both IPv4 & IPv6, it will also report which type is open, if both are open or closed and it will also give an error message if it encountered an error at the stage of fetching a public IPv4 or IPv6 or if it encountered one when fetching a token for the port check. 

Take a look :pray: 

Signed-off-by: Victor-ray Zendai <victorray91@pm.me> 