### PR TITLE
Update ncp-diag - Change back to "gateway" as ncp-report searches for this

### DIFF
--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -130,7 +130,7 @@ GW=$(    ip r | grep "default via" | awk '{ print $3 }' | head -1 )
 IP="$(get_ip)"
 
 echo "IP|$IP"
-echo "Gateway|$GW"
+echo "gateway|$GW"
 echo "Interface|$IFACE"
 
 # Certificates


### PR DESCRIPTION
Change "Gateway" to "gateway" as ncp-report searches for "gateway" only to replace IP with "REMOVED SENSITIVE VALUE"

(Had a short Matrix-chat with Zendai already about this)

Signed-off-by: Jürgen <55851807+schoetju@users.noreply.github.com>