### PR TITLE
SSH.sh: Reenable pi user if selected in SSH

### DIFF
--- a/bin/ncp/NETWORKING/SSH.sh
+++ b/bin/ncp/NETWORKING/SSH.sh
@@ -38,6 +38,9 @@ configure()
   id "$USER" &>/dev/null || { echo "$USER doesn't exist"; return 1; }
   echo -e "$PASS\n$CONFIRM" | passwd "$USER" || return 1
 
+  # Reenable pi user
+  [[ "$USER" == "pi" ]] && usermod pi -s /bin/bash
+
   # Check for insecure default pi password ( taken from old jessie method )
   # TODO Due to Debian bug #1003151 with mkpasswd this feature is not working properly at the moment - https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1837456.html
   #local SHADOW SALT HASH

--- a/build/build-SD-rpi.sh
+++ b/build/build-SD-rpi.sh
@@ -80,11 +80,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     sed -i 's|^#PermitRootLogin .*|PermitRootLogin no|' /etc/ssh/sshd_config
 
     # default user 'pi' for SSH
-    cfg="$(jq '.' etc/ncp-config.d/SSH.cfg)"
-    cfg="$(jq '.params[1].value = "pi"'        <<<"$cfg")"
-    cfg="$(jq '.params[2].value = "raspberry"' <<<"$cfg")"
-    cfg="$(jq '.params[3].value = "raspberry"' <<<"$cfg")"
-    echo "$cfg" > /usr/local/etc/ncp-config.d/SSH.cfg
 
     # cleanup
     source etc/library.sh && run_app_unsafe post-inst.sh

--- a/etc/ncp-config.d/dnsmasq.cfg
+++ b/etc/ncp-config.d/dnsmasq.cfg
@@ -3,7 +3,7 @@
   "name": "Dnsmasq, to serve names of local machines which are not in the global DNS",
   "title": "dnsmasq",
   "description": "DNS server with cache",
-  "info": "Remember to point your PC and devices DNS or\nyour router DNS to your Raspberry Pi IP",
+  "info": "Remember to point your PC and devices DNS or\nyour router DNS to your NCP IP",
   "infotitle": "",
   "params": [
     {


### PR DESCRIPTION
Fixes #1595 by:

- Reenabling pi user if used in ncp-config/SSH
- Setting ncp user as default in ncp-config/SSH