### PR TITLE
Temporarily place backup to BASEDIR

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -94,7 +94,7 @@ wget -q "$URL" -O nextcloud.tar.bz2 || { echo "Error downloading"; exit 1; }
 
 # backup
 ####################
-BKPDIR=/var/www/
+BKPDIR="$BASEDIR"
 WITH_DATA=no
 COMPRESSED=yes
 LIMIT=0


### PR DESCRIPTION
Improves docker compatibility. Placing the backup file in /var/www/ will cause a failure in rolling back the update on containerized setups ("Can only restore from ext/btrfs/zfs filesystems"). The host filesystem is most likely compatible so using $BASEDIR as the backup location *should* solve this issue for most users.

Signed-off-by: MB-Finski <64466176+MB-Finski@users.noreply.github.com>