### PR TITLE
Change backup directory for docker compatibility

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -165,7 +165,7 @@ rollback() {
   rm -rf /var/www/nextcloud.tar.bz2 "$BASEDIR"/nextcloud-old
   echo "Rolling back to backup $BKP..."
   local TMPDATA
-  TMPDATA="$( mktemp -d "/var/www/ncp-data.XXXXXX" )" || { echo "Failed to create temp dir" >&2; exit 1; }
+  TMPDATA="$( mktemp -d "$BASEDIR/recovery/ncp-data.XXXXXX" )" || { echo "Failed to create temp dir" >&2; exit 1; }
   [[ "$DATADIR" == "$BASEDIR/nextcloud/data" ]] && mv -T "$DATADIR" "$TMPDATA"
   ncp-restore "$BKP" || { echo "Rollback failed! Data left at $TMPDATA"; exit 1; }
   [[ "$DATADIR" == "$BASEDIR/nextcloud/data" ]] && { rm -rf "$DATADIR"; mv -T "$TMPDATA" "$DATADIR"; }


### PR DESCRIPTION
Improve docker compatibility: Change the backup directory for ./nextcloud/data to reside within the host file system (basedir) so as to avoid moving the data folder back and forth between the docker container and the host file system. In situations where the nextcloud data takes up more than the free available space on the host system, this may lead to loosing some or all of the data.

Signed-off-by: MB-Finski <64466176+MB-Finski@users.noreply.github.com>