### PR TITLE
Update log2ram to latest 1.6.1 release.

### DIFF
--- a/bin/ncp/SYSTEM/nc-ramlogs.sh
+++ b/bin/ncp/SYSTEM/nc-ramlogs.sh
@@ -17,7 +17,7 @@ is_active()
 
 install()
 {
-  VERSION=1.5.2
+  VERSION=1.6.1
   [[ -d /var/log.hdd ]] || [[ -d /var/hdd.log ]] && { echo "log2ram detected, not installing"; return; }
   cd /tmp
   curl -Lo log2ram.tar.gz https://github.com/azlux/log2ram/archive/${VERSION}.tar.gz


### PR DESCRIPTION
Update to latest log2ram stable release for the benefit:

- Convert from CRON to systemd.timer, which is supported by NCP base images nowadays.
- rsync by default for better performance.

Personally I have been running 1.6.1 log2ram for a month and it performs just as good as before, if not better. 