### PR TITLE
Fix rm path for update package

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -129,7 +129,7 @@ trap rollback_simple INT TERM HUP ERR
 echo "Install Nextcloud $VER..."
 mv -T nextcloud nextcloud-old
 tar -xf nextcloud.tar.bz2             # && false # test point
-rm -rf /var/www/nextcloud.tar.bz2
+rm -rf "$BASEDIR"/nextcloud.tar.bz2
 
 # copy old config
 ####################
@@ -143,7 +143,7 @@ cp -raT nextcloud-old/themes/ nextcloud/themes/
 ####################
 for app in nextcloudpi previewgenerator; do
   if [[ -d nextcloud-old/apps/"${app}" ]]; then
-    cp -r -L nextcloud-old/apps/"${app}" /var/www/nextcloud/apps/
+    cp -r -L nextcloud-old/apps/"${app}" nextcloud/apps/
   fi
 done
 

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -165,7 +165,7 @@ rollback() {
   rm -rf /var/www/nextcloud.tar.bz2 "$BASEDIR"/nextcloud-old
   echo "Rolling back to backup $BKP..."
   local TMPDATA
-  TMPDATA="$( mktemp -d "/var/www/ncp-data.XXXXXX" )" || { echo "Failed to create temp dir" >&2; exit 1; }
+  TMPDATA="$( mktemp -d "$BASEDIR/recovery/ncp-data.XXXXXX" )" || { echo "Failed to create temp dir" >&2; exit 1; }
   [[ "$DATADIR" == "$BASEDIR/nextcloud/data" ]] && mv -T "$DATADIR" "$TMPDATA"
   ncp-restore "$BKP" || { echo "Rollback failed! Data left at $TMPDATA"; exit 1; }
   [[ "$DATADIR" == "$BASEDIR/nextcloud/data" ]] && { rm -rf "$DATADIR"; mv -T "$TMPDATA" "$DATADIR"; }

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -94,7 +94,7 @@ wget -q "$URL" -O nextcloud.tar.bz2 || { echo "Error downloading"; exit 1; }
 
 # backup
 ####################
-BKPDIR=/var/www/
+BKPDIR="$BASEDIR"
 WITH_DATA=no
 COMPRESSED=yes
 LIMIT=0

--- a/ncp-web/index.php
+++ b/ncp-web/index.php
@@ -134,7 +134,7 @@ HTML;
 
   <header role="banner"><div id="header">
     <div id="header-left">
-      <a href="https://ownyourbits.com" id="nextcloudpi" target="_blank" tabindex="1">
+      <a href="https://nextcloudpi.com" id="nextcloudpi" target="_blank" tabindex="1">
         <div class="logo-icon">
            <h1 class="hidden-visually">NextCloudPi</h1>
         </div>
@@ -173,7 +173,7 @@ HTML;
               <input type="text" id="search-box" placeholder="find ncp-app" size="40">
           </div>
       </div>
-      <a href="https://ownyourbits.com" id="nextcloud-btn" target="_blank" tabindex="1" title="<?php echo $l->__("Launch Nextcloud"); ?>">
+      <a href="https://nextcloudpi.com/" id="nextcloud-btn" target="_blank" tabindex="1" title="<?php echo $l->__("Launch Nextcloud"); ?>">
         <div id="nc-button">
             <div class="expand">
                 <div class="icon-nc-white"></div>
@@ -207,7 +207,7 @@ HTML;
           </div>
         </div>
       </a>
-      <a href="https://github.com/nextcloud/nextcloudpi/wiki" target="_blank" tabindex="1"  title="<?php echo $l->__("NextCloudPi Wiki"); ?>">
+      <a href="https://docs.nextcloudpi.com/" target="_blank" tabindex="1"  title="<?php echo $l->__("NextCloudPi Wiki"); ?>">
         <div id="nc-button">
             <div class="expand">
                 <div class="icon-nc-info"></div>


### PR DESCRIPTION
Fixes a bening bug where the nextcloud update package won't be removed after unpacking when the code is run inside a docker container.

Also, for readability/clarity, remove an unnecessary "/var/www" from a cp command.

Edit: As a side note, the ncp-update-nc script uses absolute and relative path references variably. Absolute references using either $BASEDIR or $DATADIR would perhaps make the script more robust and future proof. Would such a commit/pull request make sense?

Signed-off-by: MB-Finski <64466176+MB-Finski@users.noreply.github.com>