### PR TITLE
Skip $DATADIR when fixing permissions

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -149,6 +149,13 @@ done
 
 #false # test point
 
+# fix permissions
+####################
+echo "Fix permissions..."
+chown -R www-data:www-data nextcloud
+find nextcloud/ -type d -exec chmod 750 {} \;
+find nextcloud/ -type f -exec chmod 640 {} \;
+
 # copy data if it was at the default location
 ####################
 if [[ "$DATADIR" == "/var/www/nextcloud/data" ]] || [[ "$DATADIR" == "/data/nextcloud/data" ]]; then
@@ -174,13 +181,6 @@ rollback() {
   exit 1
 }
 trap rollback INT TERM HUP ERR
-
-# fix permissions
-####################
-echo "Fix permissions..."
-chown -R www-data:www-data nextcloud
-find nextcloud/ -type d -exec chmod 750 {} \;
-find nextcloud/ -type f -exec chmod 640 {} \;
 
 # upgrade
 ####################

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -94,7 +94,7 @@ wget -q "$URL" -O nextcloud.tar.bz2 || { echo "Error downloading"; exit 1; }
 
 # backup
 ####################
-BKPDIR=/var/www/
+BKPDIR="$BASEDIR"
 WITH_DATA=no
 COMPRESSED=yes
 LIMIT=0

--- a/bin/ncp/NETWORKING/SSH.sh
+++ b/bin/ncp/NETWORKING/SSH.sh
@@ -15,7 +15,7 @@ is_active()
   systemctl -q is-enabled ssh &>/dev/null
 }
 
-configure() 
+configure()
 {
   [[ $ACTIVE != "yes" ]]  && {
     systemctl stop    ssh
@@ -29,8 +29,8 @@ configure()
     echo "Refusing to use the default Raspbian user and password. It's insecure"
     return 1
   }
-  [[ "$USER" == "root" ]] && [[ "$PASS" == "1234" ]] && {
-    echo "Refusing to use the default Armbian user and password. It's insecure"
+  [[ "$USER" == "root" ]] && {
+    echo "Refusing to use the root user for SSH. It's insecure"
     return 1
   }
 
@@ -39,7 +39,7 @@ configure()
   echo -e "$PASS\n$CONFIRM" | passwd "$USER" || return 1
 
   # Reenable pi user
-  [[ "$USER" == "pi" ]] && usermod pi -s /bin/bash
+  usermod "$USER" -s /bin/bash
 
   # Check for insecure default pi password ( taken from old jessie method )
   # TODO Due to Debian bug #1003151 with mkpasswd this feature is not working properly at the moment - https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1837456.html

--- a/ncp-web/index.php
+++ b/ncp-web/index.php
@@ -134,7 +134,7 @@ HTML;
 
   <header role="banner"><div id="header">
     <div id="header-left">
-      <a href="https://ownyourbits.com" id="nextcloudpi" target="_blank" tabindex="1">
+      <a href="https://nextcloudpi.com" id="nextcloudpi" target="_blank" tabindex="1">
         <div class="logo-icon">
            <h1 class="hidden-visually">NextCloudPi</h1>
         </div>
@@ -173,7 +173,7 @@ HTML;
               <input type="text" id="search-box" placeholder="find ncp-app" size="40">
           </div>
       </div>
-      <a href="https://ownyourbits.com" id="nextcloud-btn" target="_blank" tabindex="1" title="<?php echo $l->__("Launch Nextcloud"); ?>">
+      <a href="https://nextcloudpi.com/" id="nextcloud-btn" target="_blank" tabindex="1" title="<?php echo $l->__("Launch Nextcloud"); ?>">
         <div id="nc-button">
             <div class="expand">
                 <div class="icon-nc-white"></div>
@@ -207,7 +207,7 @@ HTML;
           </div>
         </div>
       </a>
-      <a href="https://github.com/nextcloud/nextcloudpi/wiki" target="_blank" tabindex="1"  title="<?php echo $l->__("NextCloudPi Wiki"); ?>">
+      <a href="https://docs.nextcloudpi.com/" target="_blank" tabindex="1"  title="<?php echo $l->__("NextCloudPi Wiki"); ?>">
         <div id="nc-button">
             <div class="expand">
                 <div class="icon-nc-info"></div>


### PR DESCRIPTION
The data directory contains potentially hundreds of thousands files and iterating through all of them thrice will make the upgrade process slow (hours instead of minutes). This arguably results in unnecessary downtime.

This commit proposes skipping fixing permissions/ownership for the data directory since "mv" (should) perserve them when performing a simple upgrade. This would make upgrading considerably faster.

Signed-off-by: MB-Finski <64466176+MB-Finski@users.noreply.github.com>