### PR TITLE
Update update.sh - 32bit architecture check

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -68,6 +68,24 @@ then
   exit 1
 fi
 
+# Used to prevent updates beyond Nextcloud v.24, as v.25 does not support 32bit architecture.
+# See System Requirements: https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html
+# See Nextcloud Changelog for current latest versions: https://nextcloud.com/changelog/#latest24
+# The escaped quotes are to add double-quotation marks for the String comparison in the IF-state
+if [[ "$ARCH" == "armv7" ]]
+then
+  LATEST_NC24_VERSION="\"$(curl -sSL https://nextcloud.com/changelog/#latest24 | grep 'Version 24' | awk '{print $3}' | head -1)\""
+  if [[ "$VER" > "$LATEST_NC24_VERSION" ]]
+  then
+    ERRMSG="This system is running a 32bit architecture and is trying to update beyond the latest version for NC24, "
+    ERRMSG+="this will not work as 32bit support is not available after NC24, latest version for NC24 is: ${LATEST_NC24_VERSION}\n\n"
+    ERRMSG+="See latest available version for NC24: https://nextcloud.com/changelog/#latest24 \n"
+    ERRMSG+="See system requirements for latest NC release: https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html \n"
+    printf "${ERRMSG}"
+    exit 1
+  fi
+fi
+
 # make sure that cron.php is not running and there are no pending jobs
 # https://github.com/nextcloud/server/issues/10949
 pgrep -cf cron.php &>/dev/null && { pkill -f cron.php; sleep 3; }

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -74,7 +74,7 @@ fi
 # The escaped quotes are to add double-quotation marks for the String comparison in the IF-state
 if [[ "$ARCH" == "armv7" ]]
 then
-  LATEST_NC24_VERSION="\"$(curl -sSL https://nextcloud.com/changelog/#latest24 | grep 'Version 24' | awk '{print $3}' | head -1)\""
+  LATEST_NC24_VERSION="$(curl -sSL https://nextcloud.com/changelog/#latest24 | grep 'Version 24' | awk '{print $3}' | head -1)"
   if [[ "$VER" > "$LATEST_NC24_VERSION" ]]
   then
     ERRMSG="This system is running a 32bit architecture and is trying to update beyond the latest version for NC24, "


### PR DESCRIPTION
Added an architecture check that stops the updater should it detect a 32bit architecture that is trying to update beyond the latest version for Nextcloud 24, which is the final version with 32bit support. 

It will also check what the currently latest version is for NC24 from Nextcloud's changelog website. 

I think this should be enough to prevent 32bit systems from updating beyond a supported release but it would be much appreciated if someone with a 32bit system could actually confirm this :pray: 

I have tested it locally by changing the variables to my "amd64" system and "pretending" it is a 32bit one. 

Signed-off-by: Owl <12261439+ZendaiOwl@users.noreply.github.com>