### PR TITLE
Clean-up OPcache configurations

### DIFF
--- a/etc/ncp-templates/php/opcache.ini.sh
+++ b/etc/ncp-templates/php/opcache.ini.sh
@@ -16,13 +16,7 @@ fi
 
 cat <<EOF
 zend_extension=opcache.so
-opcache.enable=1
-opcache.enable_cli=1
-opcache.fast_shutdown=1
-opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=10000
-opcache.memory_consumption=128
-opcache.save_comments=1
-opcache.revalidate_freq=1
+opcache.interned_strings_buffer=16
+opcache.revalidate_freq=60
 opcache.file_cache=${TMP_DIR};
 EOF


### PR DESCRIPTION
This PR serves to clean-up the OPcache configurations in opcache.ini.sh.
===
Removed configurations
---
**These configurations were removed as they are already the defaults in PHP ([see PHP OPcache configuration docs](https://www.php.net/manual/en/opcache.configuration.php)):**
```
opcache.enable=1
opcache.max_accelerated_files=10000
opcache.save_comments=1
opcache.memory_consumption=128
```
**These configurations were also removed, with justifications:**
```
opcache.fast_shutdown = 1
```
opcache.fast_shutdown directive was removed since PHP 7.2.0 ([see opcache.fast_shutdown configuration](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.fast-shutdown)). Similar PR:
- #1660.
```
opcache.enable_cli=1
```
opcache.enable_cli=1 was removed from Nextcloud's recommended configurations due to it being bad for performance. See issue:
- https://github.com/nextcloud/documentation/issues/1439.
>The recommendation to set opcache.enable_cli=1 is actually bad for performance.

___
Recommended configurations
---
**These are recommended configurations ([see Enabling PHP OPcache - Nextcloud docs](https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html#enable-php-opcache)):**
```
opcache.save_comments = 1
```
>Nextcloud strictly requires code comments to be preserved in opcode, which is the default.

opcache.save_comments is required by Nextcloud. However, it is also the default value in PHP, therefore removed.
```
opcache.revalidate_freq = 60
```
OR
```
opcache.validate_timestamps = 0
```
> Since Nextcloud handles cache revalidation internally when required, the revalidation frequency can be reduced or completely disabled to enhance performance.

opcache.revalidate_freq is recommended to be set to '60' to revalidate cached scripts every 60 seconds (as opposed to the 2 seconds default in PHP). The revalidation frequency can be disabled by setting opcache.validate_timestamps to '0'.

**Other recommended configuration by Nextcloud (undocumented):**
```
opcache.interned_strings_buffer=16
```
Nextcloud have increased opcache.interned_strings_buffer from '8' to '16' to avoid the following error message:
>The OPcache interned strings buffer is nearly full. To assure that repeating strings can be effectively cached, it is recommended to apply opcache.interned_strings_buffer to your PHP configuration with a value higher than 8.

See PR:
- https://github.com/nextcloud/docker/pull/1702

___
Personally, I have tested the configuration by modifying /etc/php/8.1/mods-available/opcache.ini and there were no issues after restarting the service.

However, if any issues arises after restarting the service, I would recommend to clear the file cache in /tmp and then restarting the service.

Note that I have tested this on a Docker instance instead of a bare metal installation.