### PR TITLE
Improve performance of the "fix permissions" step in ncp-update-nc

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -179,8 +179,9 @@ trap rollback INT TERM HUP ERR
 ####################
 echo "Fix permissions..."
 chown -R www-data:www-data nextcloud
-find nextcloud/ -type d -exec chmod 750 {} \;
-find nextcloud/ -type f -exec chmod 640 {} \;
+
+# this command sets the permissions to 750 for directories and to 640 for files
+chmod -R a-x,u=rwX,g=rX,o= nextcloud
 
 # upgrade
 ####################


### PR DESCRIPTION
The "fix permissions" step is really slow when the nextcloud folder contains a lot of data. In a docker setup the data directory is in nextcloud/data so the folder can be really big. Even on my small test setup the "fix permissions" step took more than 20 minutes. Using "chmod -R ..." reduces the time to around 20 seconds.

Signed-off-by: Florian Wallner <asdf@walura.eu>