### PR TITLE
࿓❯ Removed the extra forward slash in the config directory variable

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -22,7 +22,7 @@ then
   [[ "$ALLOW_UPDATE_SCRIPT" == "1" ]] || exit 1
 fi
 
-CONFDIR=/usr/local/etc/ncp-config.d/
+CONFDIR=/usr/local/etc/ncp-config.d
 UPDATESDIR=updates
 
 # don't make sense in a docker container


### PR DESCRIPTION
Fixes the extra forward slash that gets introduced in the various paths inside the update.sh file.  

Signed-off-by: Victor-ray, S <12261439+ZendaiOwl@users.noreply.github.com>