### PR TITLE
[fix] ncp-update-nc: Don't remove systemd during PHP rollback

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -243,7 +243,7 @@ then
     a2disconf php${PHPVER_NEW}-fpm
     rm /etc/apt/sources.list.d/php.list
     apt-get update
-    apt-get remove --purge -y "${PHP_PACKAGES_NEW[@]}" systemd
+    apt-get remove --purge -y "${PHP_PACKAGES_NEW[@]}"
     apt-get install -y --no-install-recommends -t "$RELEASE" "${PHP_PACKAGES_OLD[@]}"
     set_ncpcfg "php_version" "${PHPVER_OLD}"
     install_template "php/opcache.ini.sh" "/etc/php/${PHPVER_NEW}/mods-available/opcache.ini"


### PR DESCRIPTION
Signed-off-by: Tobias Knöppler <6317548+theCalcaholic@users.noreply.github.com>