### PR TITLE
[Fix] ncp-update-nc: Clear opcache before removing PHP, to avoid breaking t…

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -262,6 +262,8 @@ then
   echo "deb https://packages.sury.org/php/ ${RELEASE%-security} main" > /etc/apt/sources.list.d/php.list
   apt-get update
 
+  clear_opcache
+
   echo "Stopping apache and  php-fpm..."
   service "php${PHPVER_OLD}-fpm" stop
   service apache2 stop
@@ -278,7 +280,6 @@ then
   set_ncpcfg "php_version" "${PHPVER_NEW}"
   install_template "php/opcache.ini.sh" "/etc/php/${PHPVER_NEW}/mods-available/opcache.ini"
   ( set -e; export PHPVER="${PHPVER_NEW}"; run_app nc-limits )
-  clear_opcache
 
   a2enconf "php${PHPVER_NEW}-fpm"
 


### PR DESCRIPTION
…he PHP upgrade

Signed-off-by: Tobias Knöppler <6317548+theCalcaholic@users.noreply.github.com>