### PR TITLE
Improved default for php max children

### DIFF
--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -42,10 +42,13 @@ tmpl_php_max_filesize() {
 }
 
 tmpl_php_threads() {
+  local TOTAL_MEM="$( get_total_mem )"
   local PHPTHREADS="$(find_app_param nc-limits PHPTHREADS)"
-  [[ $PHPTHREADS -eq 0 ]] && PHPTHREADS=$(nproc)
-  [[ $PHPTHREADS -lt 6 ]] && PHPTHREADS=6
-  echo -n "$PHPTHREADS"
+  # By default restricted by memory / 100MB
+  [[ $PHPTHREADS -eq 0 ]] && PHPTHREADS=$(( TOTAL_MEM / ( 100 * 1024 * 1024 ) ))
+  # Minimum 16
+  [[ $PHPTHREADS -lt 16 ]] && PHPTHREADS=16
+   echo -n "$PHPTHREADS"
 }
 
 configure()

--- a/etc/ncp-config.d/nc-limits.cfg
+++ b/etc/ncp-config.d/nc-limits.cfg
@@ -2,7 +2,7 @@
   "id": "nc-limits",
   "name": "Nc-limits",
   "title": "nc-limits",
-  "description": "Configure system limits for NextCloudPi",
+  "description": "Configure system limits for NextcloudPi",
   "info": "Examples: 200M or 2G. Write 0 for autoconfig",
   "infotitle": "",
   "params": [

--- a/etc/ncp-templates/php/pool.d.www.conf.sh
+++ b/etc/ncp-templates/php/pool.d.www.conf.sh
@@ -9,7 +9,7 @@ if [[ "$1" == "--defaults" ]] || ! [[ -f "${BINDIR}/CONFIG/nc-limits.sh" ]]
 then
   echo "INFO: Restoring template to default settings" >&2
 
-  PHPTHREADS=6
+  PHPTHREADS=16
 else
   PHPTHREADS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_threads)"
 fi


### PR DESCRIPTION
Like described in issue https://github.com/nextcloud/nextcloudpi/issues/1624
the default for php.ini setting pm.max_children has been improved to be equal total_mem / 100 MB but 16 at minimum.
