### PR TITLE
Add DISABLE_FS_CHECK check to nc-database.sh

### DIFF
--- a/bin/ncp/CONFIG/nc-database.sh
+++ b/bin/ncp/CONFIG/nc-database.sh
@@ -37,7 +37,10 @@ configure()
   local BASEDIR=$( dirname "$DBDIR" )
   mkdir -p "$BASEDIR"
 
-  grep -q -e ext -e btrfs <( stat -fc%T "$BASEDIR" ) || { echo -e "Only ext/btrfs filesystems can hold the data directory (found '$(stat -fc%T "${BASEDIR}")"; return 1; }
+  [[ "$DISABLE_FS_CHECK" == 1 ]] || grep -q -e ext -e btrfs <( stat -fc%T "$BASEDIR" ) || {
+    echo -e "Only ext/btrfs filesystems can hold the data directory (found '$(stat -fc%T "${BASEDIR}")";
+    return 1;
+  }
 
   sudo -u mysql test -x "$BASEDIR" || { echo -e "ERROR: the user mysql does not have access permissions over $BASEDIR"; return 1; }
 


### PR DESCRIPTION
Added check for the env var DISABLE_FS_CHECK when running `nc-database.sh` to change the database directory.