### PR TITLE
Fix nextcloud#1573 "No snapshots found" in WEBUI and fix nextcloud#1830 restore-snapshot

### DIFF
--- a/bin/ncp/BACKUPS/nc-restore-snapshot.sh
+++ b/bin/ncp/BACKUPS/nc-restore-snapshot.sh
@@ -37,8 +37,8 @@ configure()
   btrfs-snp $mountpoint autobackup 0 0 ../ncp-snapshots || return 1
 
   save_maintenance_mode
-  btrfs subvolume delete   "$datadir" || return 1
-  btrfs subvolume snapshot "$SNAPSHOT" "$datadir"
+  btrfs subvolume delete   "$mountpoint" || return 1
+  btrfs subvolume snapshot "$SNAPSHOT" "$mountpoint"
   restore_maintenance_mode
   ncp-scan
 

--- a/ncp-web/backups.php
+++ b/ncp-web/backups.php
@@ -132,7 +132,7 @@ HTML;
 
 include( '/var/www/nextcloud/config/config.php' );
 
-$snap_dir = realpath($CONFIG['datadirectory'] . '/../ncp-snapshots');
+$snap_dir = realpath($CONFIG['datadirectory'] . '/../../ncp-snapshots');
 $snaps = array();
 if (file_exists($snap_dir))
 {


### PR DESCRIPTION
**Issue nextcloud#1573: No snapshots found on WEBUI backups page**
When creating BTRFS snapshots, either manually or automatically, the snapshots are stored in `/media/myCloudDrive/ncp-snapshots`. The snapshots should be displayed on WEBUI Backups page but there is an error "No snapshots found".
The reason is that [backups.php](https://github.com/nextcloud/nextcloudpi/blob/master/ncp-web/backups.php) looks for snapshots in `/media/myCloudDrive/ncdata/ncp-snapshots` which is the wrong path.
Solution: Fix the path in [backups.php](https://github.com/nextcloud/nextcloudpi/blob/master/ncp-web/backups.php), now the snapshots are displayed correctly on WEBUI Backups page.

**Issue nextcloud#1830: Restore BTRFS snapshot fails**
Restoring a BTRFS snapshot fails with "ERROR: Not a Btrfs subvolume: Invalid argument". That is because [nc-restore-snapshot.sh](https://github.com/nextcloud/nextcloudpi/blob/master/bin/ncp/BACKUPS/nc-restore-snapshot.sh) tries to delete `/media/myCloudDrive/ncdata/data` instead of `/media/myCloudDrive/ncdata`.
Thanks to @Dimitar-Boychev for pointing out the issue and providing the solution.