### PR TITLE
Fix database prefix

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -74,7 +74,7 @@ fi
 # https://github.com/nextcloud/server/issues/10949
 pgrep -cf cron.php &>/dev/null && { pkill -f cron.php; sleep 3; }
 pgrep -cf cron.php &>/dev/null && { echo "cron.php running. Abort"; exit 1; }
-mysql nextcloud <<<"UPDATE "$DB_FREFIX"jobs SET reserved_at=0;"
+mysql nextcloud <<<"UPDATE ${DB_PREFIX}jobs SET reserved_at=0;"
 
 # cleanup
 ####################

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -21,6 +21,8 @@ set -eE${DBG}
 
 VER="$1"
 BIN="${0##*/}"
+DB_PREFIX=`php -r 'include("/var/www/nextcloud/config/config.php"); print ( $CONFIG['"'dbtableprefix'"'] );'`
+echo DB_PREFIX = $DB_PREFIX
 
 source /usr/local/etc/library.sh
 
@@ -72,7 +74,7 @@ fi
 # https://github.com/nextcloud/server/issues/10949
 pgrep -cf cron.php &>/dev/null && { pkill -f cron.php; sleep 3; }
 pgrep -cf cron.php &>/dev/null && { echo "cron.php running. Abort"; exit 1; }
-mysql nextcloud <<<"UPDATE oc_jobs SET reserved_at=0;"
+mysql nextcloud <<<"UPDATE "$DB_FREFIX"jobs SET reserved_at=0;"
 
 # cleanup
 ####################


### PR DESCRIPTION
This fixes issue #1818 by getting the database prefix from the configuration file and using it in the SQL command that failed because of a hard coded database prefix.