### PR TITLE
v1.55.3

### DIFF
--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -53,7 +53,8 @@ then
 fi
 
 systemctl reset-failed ncp-update-nc 2>/dev/null ||:
-systemd-run -u 'ncp-update-nc' bash -c "set -o pipefail; DBG='${DBG:-}' /usr/local/bin/ncp-update-nc.d/update-nc.sh '${VER}' |& tee /var/log/ncp-update-nc.log"
+systemd-run -u 'ncp-update-nc' --service-type=oneshot --no-block -p TimeoutStartSec="24h" -p TimeoutStopSec="1h" \
+  bash -c "set -o pipefail; DBG='${DBG:-}' /usr/local/bin/ncp-update-nc.d/update-nc.sh '${VER}' |& tee /var/log/ncp-update-nc.log"
 sleep 1
 
 if ! [[ "$(systemctl is-active ncp-update-nc ||:)" =~ ^(active|inactive|activating|deactivating)$ ]]

--- a/bin/ncp-update-nc
+++ b/bin/ncp-update-nc
@@ -52,7 +52,7 @@ then
   exit $?
 fi
 
-systemctl reset-failed ncp-encrypt 2>/dev/null ||:
+systemctl reset-failed ncp-update-nc 2>/dev/null ||:
 systemd-run -u 'ncp-update-nc' bash -c "set -o pipefail; DBG='${DBG:-}' /usr/local/bin/ncp-update-nc.d/update-nc.sh '${VER}' |& tee /var/log/ncp-update-nc.log"
 sleep 1
 

--- a/bin/ncp-update-nc.d/update-nc.sh
+++ b/bin/ncp-update-nc.d/update-nc.sh
@@ -59,9 +59,15 @@ grep -qP "\d+\.\d+\.\d+" <<<"$TARGET_VERSION"   || { echo "Malformed version $TA
 echo "Current   Nextcloud version $CURRENT"
 echo "Requested Nextcloud version $REQUESTED_VERSION"
 echo "Selected  Nextcloud version $TARGET_VERSION"
-if [[ "$TARGET_VERSION" != "$REQUESTED_VERSION" ]]
+
+if [[ "$REQUESTED_VERSION" == "latest" ]]
+then
+  echo "INFO: You have requested an update to the latest available version that can be performed directly, which is '${TARGET_VERSION}'. Updates can only performed to the next major version (or the latest minor version of the current major version). If you run ncp-update-nc again after this update completes, a new version might be available."
+  sleep 3
+elif [[ "$TARGET_VERSION" != "$REQUESTED_VERSION" ]]
 then
   echo "INFO: You have requested an update to '${REQUESTED_VERSION}', but a direct update to '${REQUESTED_VERSION}' cannot be performed, so the latest available version that can be updated to (${TARGET_VERSION}) has been selected automatically."
+  sleep 3
 fi
 
 # make sure that cron.php is not running and there are no pending jobs

--- a/bin/ncp/CONFIG/nc-datadir.sh
+++ b/bin/ncp/CONFIG/nc-datadir.sh
@@ -103,7 +103,7 @@ configure()
   cd /var/www/nextcloud
   [[ "$BUILD_MODE" == 1 ]] || save_maintenance_mode
 
-  echo "moving data directory from ${SRCDIR} to ${BASEDIR}..."
+  echo "moving data directory from ${SRCDIR} to ${DATADIR}..."
 
   # use subvolumes, if BTRFS
   [[ "$(stat -fc%T "${BASEDIR}")" == "btrfs" ]] && ! is_docker && {

--- a/bin/ncp/CONFIG/nc-init.sh
+++ b/bin/ncp/CONFIG/nc-init.sh
@@ -189,6 +189,7 @@ EOF
   # TODO temporary workaround for https://github.com/nextcloud/server/pull/13358
   ncc -n db:convert-filecache-bigint
   ncc db:add-missing-indices
+  ncc maintenance:repair --include-expensive
 
   # Default trusted domain (only from ncp-config)
   test -f /usr/local/bin/nextcloud-domain.sh && {

--- a/bin/ncp/CONFIG/nc-previews-auto.sh
+++ b/bin/ncp/CONFIG/nc-previews-auto.sh
@@ -23,8 +23,8 @@ configure()
   grep -qP "^\d+$" <<<"$RUNTIME" || { echo "Invalid RUNTIME value $RUNTIME"; return 1; }
   RUNTIME=$((RUNTIME*60))
 
-  echo "0  2  *  *  *  root  /usr/local/bin/nc-previews" >  /etc/cron.d/ncp-previews-auto
-  chmod 644 /etc/cron.d/ncp-previews-auto
+  echo "0  2  *  *  *  root  /usr/local/bin/nc-previews" >  /etc/cron.d/nc-previews-auto
+  chmod 644 /etc/cron.d/nc-previews-auto
 
   cat > /usr/local/bin/nc-previews <<EOF
 #!/bin/bash

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # NextcloudPi Changelog
 
+## [v1.55.3](https://github.com/nextcloud/nextcloudpi/tree/v1.55.3) (2024-11-08) Nextcloud 30 and fixes
+
+### Changes
+
+- Support for Nextcloud 30 ([#1957](https://github.com/nextcloud/nextcloudpi/issues/1957))
+
+### Fixes
+
+- Fix resetting failed state of previous ncp-update-nc job ([#1992](https://github.com/nextcloud/nextcloudpi/issues/1992))
+- Fix installer on systems using resolvconf as DNS manager ([#1926](](https://github.com/nextcloud/nextcloudpi/issues/1926))
+- Fix typo that prevents ncp-previews from being disabled (Thanks @m-breitbach)
+
 ## [v1.55.2](https://github.com/nextcloud/nextcloudpi/tree/v1.55.2) (2024-09-24) Hotfix release
 
 ### Fixes

--- a/etc/ncp-config.d/nc-nextcloud.cfg
+++ b/etc/ncp-config.d/nc-nextcloud.cfg
@@ -9,7 +9,7 @@
     {
       "id": "VER",
       "name": "Version",
-      "value": "29.0.4"
+      "value": "30.0.1"
     },
     {
       "id": "MAXFILESIZE",

--- a/etc/ncp.cfg
+++ b/etc/ncp.cfg
@@ -1,5 +1,5 @@
 {
-	"nextcloud_version": "29.0.4",
+	"nextcloud_version": "30.0.1",
 	"php_version": "8.3",
 	"release": "bookworm"
 }

--- a/install.sh
+++ b/install.sh
@@ -74,11 +74,6 @@ cp etc/ncp.cfg /usr/local/etc/
 
 cp -r etc/ncp-templates /usr/local/etc/
 install_app    lamp.sh
-if [[ -d "/run/systemd/system" ]] && is_lxc
-then
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y systemd-resolved
-  systemctl enable systemd-resolved
-fi
 install_app    bin/ncp/CONFIG/nc-nextcloud.sh
 run_app_unsafe bin/ncp/CONFIG/nc-nextcloud.sh
 rm /usr/local/etc/ncp-config.d/nc-nextcloud.cfg    # armbian overlay is ro

--- a/ncp-app/appinfo/info.xml
+++ b/ncp-app/appinfo/info.xml
@@ -12,7 +12,7 @@
     <category>tools</category>
     <bugs>https://github.com/nextcloud/nextcloudpi/issues</bugs>
     <dependencies>
-        <nextcloud min-version="22" max-version="29"/>
+        <nextcloud min-version="22" max-version="30"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/ncp-previewgenerator/ncp-previewgenerator-nc21/appinfo/info.xml
+++ b/ncp-previewgenerator/ncp-previewgenerator-nc21/appinfo/info.xml
@@ -25,7 +25,7 @@ The first time you install this app, before using a cron job, you properly want 
 	</types>
 	<dependencies>
 		<php min-version="7.2"/>
-		<nextcloud min-version="20" max-version="29" />
+		<nextcloud min-version="20" max-version="30" />
 	</dependencies>
 
 	<commands>

--- a/updates/1.55.3.sh
+++ b/updates/1.55.3.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+[ -f /etc/cron.d/ncp-previews-auto ] && mv /etc/cron.d/ncp-previews-auto /etc/cron.d/nc-previews-auto


### PR DESCRIPTION

### Changes

- Support for Nextcloud 30 ([#1957](https://github.com/nextcloud/nextcloudpi/issues/1957))

### Fixes

- Fix resetting failed state of previous ncp-update-nc job ([#1992](https://github.com/nextcloud/nextcloudpi/issues/1992))
- Fix installer on systems using resolvconf as DNS manager ([#1926](](https://github.com/nextcloud/nextcloudpi/issues/1926))
- Fix typo that prevents ncp-previews from being disabled (Thanks @m-breitbach)