### PR TITLE
Fix ncpweb performance

### DIFF
--- a/etc/library.sh
+++ b/etc/library.sh
@@ -14,7 +14,6 @@ export NCDIR=/var/www/nextcloud
 export ncc=/usr/local/bin/ncc
 export NCPCFG=${NCPCFG:-etc/ncp.cfg}
 export ARCH="$(dpkg --print-architecture)"
-export DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG['"'dbtableprefix'"'];' || echo 'oc_')"
 [[ "${ARCH}" =~ ^(armhf|arm)$ ]] && ARCH="armv7"
 [[ "${ARCH}" == "arm64" ]] && ARCH=aarch64
 [[ "${ARCH}" == "amd64" ]] && ARCH=x86_64
@@ -58,6 +57,9 @@ RELEASE=$(    jq -r .release           < "$NCPCFG")
 # the default repo in bullseye is bullseye-security
 grep -Eh '^deb ' /etc/apt/sources.list | grep "${RELEASE}-security" > /dev/null && RELEASE="${RELEASE}-security"
 command -v ncc &>/dev/null && NCVER="$(ncc status 2>/dev/null | grep "version:" | awk '{ print $3 }')"
+DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG['"'dbtableprefix'"'];' || echo 'oc_')"
+
+export DB_PREFIX
 
 function configure_app()
 {

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -62,7 +62,7 @@ then
   grep -Eh '^deb ' /etc/apt/sources.list | grep "${RELEASE}-security" > /dev/null && RELEASE="${RELEASE}-security"
   command -v ncc &>/dev/null && NCVER="$(ncc status 2>/dev/null | grep "version:" | awk '{ print $3 }')"
   DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG["dbtableprefix"];')"
-  cat > /var/www/ncp-web/library-cache << EOF
+  test -d /var/www/ncp-web && cat > /var/www/ncp-web/library-cache << EOF
 NCLATESTVER="${NCLATESTVER}"
 PHPVER="${PHPVER}"
 RELEASE="${RELEASE}"

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -61,7 +61,9 @@ then
   # the default repo in bullseye is bullseye-security
   grep -Eh '^deb ' /etc/apt/sources.list | grep "${RELEASE}-security" > /dev/null && RELEASE="${RELEASE}-security"
   command -v ncc &>/dev/null && NCVER="$(ncc status 2>/dev/null | grep "version:" | awk '{ print $3 }')"
-  DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG["dbtableprefix"];')"
+  if [ -s /var/www/nextcloud/config/config.php ];then
+    DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG["dbtableprefix"];')"
+  fi
   test -d /var/www/ncp-web && cat > /var/www/ncp-web/library-cache << EOF
 NCLATESTVER="${NCLATESTVER}"
 PHPVER="${PHPVER}"

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -57,9 +57,9 @@ RELEASE=$(    jq -r .release           < "$NCPCFG")
 # the default repo in bullseye is bullseye-security
 grep -Eh '^deb ' /etc/apt/sources.list | grep "${RELEASE}-security" > /dev/null && RELEASE="${RELEASE}-security"
 command -v ncc &>/dev/null && NCVER="$(ncc status 2>/dev/null | grep "version:" | awk '{ print $3 }')"
-DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG['"'dbtableprefix'"'];' || echo 'oc_')"
+DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG["dbtableprefix"];')"
 
-export DB_PREFIX
+export DB_PREFIX=${DB_PREFIX:-oc_}
 
 function configure_app()
 {


### PR DESCRIPTION
The https://localhost:4443 is very slow on a PI. Main reason is the very slow jq-1.5 on recent Armbians that is executed several times when "source etc/library.sh". One can generally install a faster alternative (see https://github.com/01mf02/jaq) but also this MR implements some fast caching for CPU hogging lines in library.sh