### PR TITLE
#2069: Apply fix for notify_push reinstall during Nextcloud updates

### DIFF
--- a/bin/ncp-update-nc.d/update-nc.sh
+++ b/bin/ncp-update-nc.d/update-nc.sh
@@ -144,7 +144,7 @@ cp -raT nextcloud-old/themes/ nextcloud/themes/
 
 # copy old NCP apps
 ####################
-for app in nextcloudpi previewgenerator; do
+for app in nextcloudpi previewgenerator notify_push; do
   if [[ -d nextcloud-old/apps/"${app}" ]]; then
     cp -r -L nextcloud-old/apps/"${app}" /var/www/nextcloud/apps/
   fi


### PR DESCRIPTION
Fix to address issue #2069 

Simply adding notify_push add into the copied app list from old instances.

Tested during upgrade from 31.0.8 to 31.0.9 on RPi5 Image with Armbian. 