### PR TITLE
fix: replace legacy /etc/issue with /etc/os-release

### DIFF
--- a/bin/ncp-diag
+++ b/bin/ncp-diag
@@ -15,7 +15,12 @@ source /usr/local/etc/library.sh
 # Distro, NCP version and tag
 echo "NextcloudPi version|$( cat /usr/local/etc/ncp-version )"
 [[ -f /usr/local/etc/ncp-baseimage ]] && echo "NextcloudPi image|$( cat /usr/local/etc/ncp-baseimage )"
-echo "OS|$(sed 's| \\n \\l||' /etc/issue). $(uname -r) ($(uname -m))"
+if [[ -r /etc/os-release ]]; then
+  . /etc/os-release
+  echo "OS|$PRETTY_NAME. $(uname -r) ($(uname -m))"
+else
+  echo "OS|unknown. $(uname -r) ($(uname -m))"
+fi
 
 # Data
 DATADIR="$( grep datadirectory /var/www/nextcloud/config/config.php |


### PR DESCRIPTION
After upgrading to Debian 13, NextcloudPi still reported Debian 12.

This was traced to ncp-diag, which currently reads /etc/issue to determine the OS version. /etc/issue is a legacy login banner and is not updated during distribution upgrades.

This PR switches OS detection to /etc/os-release, which is the standard and is automatically updated on dist-upgrades.

```bash
# before
OS | Debian GNU/Linux 12. 6.17.4-2-pve (x86_64)
# after
OS | Debian GNU/Linux 13 (trixie). 6.17.4-2-pve (x86_64)
```