### PR TITLE
Fix/xss and undefined http accept language

### DIFF
--- a/ncp-web/index.php
+++ b/ncp-web/index.php
@@ -65,7 +65,7 @@ header("Link: </js/minified.js>; rel=preload; as=script;,</js/ncp.js>; rel=prelo
 <?php
   require("L10N.php");
   try {
-    $l = new L10N($_SERVER["HTTP_ACCEPT_LANGUAGE"], $l10nDir, $modules_path);
+    $l = new L10N(($_SERVER["HTTP_ACCEPT_LANGUAGE"] ?? ''), $l10nDir, $modules_path);
   } catch (Exception $e) {
     die("<p class='error'>Error while loading localizations!</p>");
   }
@@ -287,7 +287,7 @@ HTML
         <div id="logs-wrapper" class="content-box <?php if(!array_key_exists('app',$_GET) || (array_key_exists('app',$_GET) && $_GET['app'] != 'logs')) echo 'hidden';?>">
           <h2 class="text-title"><?php echo $l->__("NextcloudPi logs"); ?></h2>
           <div id="logs-content" class="table-wrapper">
-            <div id="logs-details-box" class="outputbox"><?php echo str_replace(array("\r\n", "\n", "\r"), '<br/>', file_get_contents('/var/log/ncp.log')) ?></div>
+            <div id="logs-details-box" class="outputbox"><?php echo str_replace(array("\r\n", "\n", "\r"), '<br/>', htmlspecialchars(file_get_contents('/var/log/ncp.log'), ENT_QUOTES, 'UTF-8')) ?></div>
             <div id="log-download-btn-wrapper"><input id="log-download-btn" type="button" value="Download"/></div>
           </div>
   </div>

--- a/ncp-web/ncp-launcher.php
+++ b/ncp-web/ncp-launcher.php
@@ -21,7 +21,7 @@ ignore_user_abort(true);
 //
 require("L10N.php");
 try {
-  $l = new L10N($_SERVER["HTTP_ACCEPT_LANGUAGE"], $l10nDir, $cfg_dir);
+  $l = new L10N(($_SERVER["HTTP_ACCEPT_LANGUAGE"] ?? ''), $l10nDir, $cfg_dir);
 } catch (Exception $e) {
   die(json_encode("<p class='error'>Error while loading localizations!</p>"));
 }


### PR DESCRIPTION
From the original PR (#2096):

## Summary

This PR fixes two issues in the NextCloudPi web panel that can cause the admin dashboard to fail loading:

### 1. XSS vulnerability / HTML parser breakage via ncp.log content

**Problem:** When `/var/log/ncp.log` contains HTML-like strings (e.g., `<strftime_format>` from backup operations), the unescaped output in `index.php` breaks the browser's HTML parser. This causes:
- The browser to treat log content as HTML tags
- Subsequent `<script>` tags to be ignored
- `minified.js` and `ncp.js` never execute
- Dashboard shows infinite "System Info" loading spinner

**Fix:** Wrap `file_get_contents('/var/log/ncp.log')` with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` to properly escape HTML entities.

### 2. PHP warning for undefined HTTP_ACCEPT_LANGUAGE array key

**Problem:** When HTTP requests lack the `Accept-Language` header (common with API calls, curl, automated scripts), PHP emits an "Undefined array key" warning. In `ncp-launcher.php`, this warning can corrupt JSON responses.

**Fix:** Use PHP's null coalescing operator (`?? ''`) to provide a default empty string when the header is missing.

## Files Changed

- `ncp-web/index.php` (lines 68, 290)
- `ncp-web/ncp-launcher.php` (line 24)

## Testing

Tested on NextCloudPi running in an LXC container on Proxmox. After applying these fixes:
- Dashboard loads correctly even with HTML-like content in logs
- No PHP warnings in Apache error logs for missing Accept-Language header
- All existing functionality remains intact

## Related Issues

This addresses a real-world issue where users see an infinite loading spinner on the "System Info" section of the NCP admin panel.
