### PR TITLE
Fix backup cache handling when JSON decode returns null

### DIFF
--- a/ncp-web/backups.php
+++ b/ncp-web/backups.php
@@ -55,7 +55,10 @@ HTML;
     $cache_str = file_get_contents($cache_file)
       or exit("error opening ${cache_file}");
 
-    $cache = json_decode($cache_str, true) or [];
+    $cache = json_decode($cache_str, true);
+    if (!is_array($cache)) {
+      $cache = [];
+    }
   } else {
     $cache = [];
   }


### PR DESCRIPTION
The WebUI crashes when the cache file contains invalid or empty JSON.

This happens because json_decode($cache_str, true) may return null.
The previous implementation used `or [ ]`, which does not assign the fallback array as intended due to PHP operator precedence.

This patch ensures that $cache is always initialized as an array:
- If json_decode returns a valid array, it is used
- Otherwise, $cache falls back to an empty array

This prevents runtime errors when accessing the cache.