### PR TITLE
Feature/debian 13 support / Issue #2082

### DIFF
--- a/bin/ncp-dist-upgrade.d/debian-12.sh
+++ b/bin/ncp-dist-upgrade.d/debian-12.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+new_cfg=/usr/local/etc/ncp-recommended.cfg
+[[ -f "${new_cfg}" ]] || { echo "Already on the latest recommended distribution. Abort." >&2; exit 1; }
+
+echo "
+>>> ATTENTION <<<
+This is a dangerous process that is only guaranteed to work properly if you
+have not made manual changes in the system. Backup the SD card first and
+proceed at your own risk.
+
+Note that this is not a requirement for NCP to continue working properly.
+The current distribution will keep receiving updates for some time.
+
+Do you want to continue? [y/N]"
+
+if [[ "${DEBIAN_FRONTEND:-}" == "noninteractive" ]] || ! [[ -t 0 ]]
+then
+  echo "Noninteractive environment detected. Automatically proceeding in 30 seconds..."
+  sleep 30
+else
+  read -n1 -r key
+  [[ "${key,,}" == y ]] || exit 0
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+source /usr/local/etc/library.sh
+is_more_recent_than "${PHPVER}.0" "8.2.0" || {
+  echo "You still have PHP version ${PHPVER} installed. Please update to the latest supported version of nextcloud (which will also update your PHP version) before proceeding with the distribution upgrade."
+  echo "Exiting."
+  exit 1
+}
+save_maintenance_mode
+
+# Perform dist-upgrade
+
+apt-get update
+apt-get upgrade -y
+for aptlist in /etc/apt/sources.list /etc/apt/sources.list.d/{php.list,armbian.list,raspi.list}
+do
+  [ -f "$aptlist" ] && sed -i -e "s/bookworm/trixie/g" "$aptlist"
+done
+for aptlist in /etc/apt/sources.list.d/*.list
+do
+  [[ "$aptlist" =~ "/etc/apt/sources.list.d/"(php|armbian|raspi)".list" ]] || {
+    echo "Disabling repositories from \"$aptlist\""
+    sed -i -e "s/deb/#deb/g" "$aptlist"
+  }
+done
+apt-get update
+apt-get upgrade -y dpkg
+apt-get upgrade -y --without-new-pkgs
+if is_lxc
+then
+  # Required to avoid breakage of /etc/resolv.conf
+  apt-get install -y --no-install-recommends systemd-resolved && systemctl enable --now systemd-resolved
+fi
+apt-get full-upgrade -y
+apt-get --purge autoremove -y
+
+restore_maintenance_mode
+cfg="$(jq "." "$NCPCFG")"
+cfg="$(jq ".release = \"trixie\"" <<<"$cfg")"
+echo "$cfg" > "$NCPCFG"
+rm -f /etc/update-motd.d/30ncp-dist-upgrade
+rm -f /usr/local/etc/ncp-recommended.cfg
+
+echo "Update to Debian 13 (trixie) successful."
+
+is_active_app unattended-upgrades && {
+  echo "Setting up unattended upgrades..."
+  run_app unattended-upgrades || true
+  echo "done."
+}

--- a/bin/ncp-dist-upgrade.d/debian-12.sh
+++ b/bin/ncp-dist-upgrade.d/debian-12.sh
@@ -53,11 +53,7 @@ done
 apt-get update
 apt-get upgrade -y dpkg
 apt-get upgrade -y --without-new-pkgs
-if is_lxc
-then
-  # Required to avoid breakage of /etc/resolv.conf
-  apt-get install -y --no-install-recommends systemd-resolved && systemctl enable --now systemd-resolved
-fi
+
 apt-get full-upgrade -y
 apt-get --purge autoremove -y
 

--- a/bin/ncp-update-nc.d/update-nc.sh
+++ b/bin/ncp-update-nc.d/update-nc.sh
@@ -260,6 +260,11 @@ then
 
   # Reload library.sh to reset PHPVER
   source /usr/local/etc/library.sh
+elif is_more_recent_than "8.3.0" "${PHPVER}.0" && [[ "$DEBIAN_VERSION" -ge 13 ]]
+then
+  /usr/local/bin/ncp-update-nc.d/upgrade-php-trixie-8.3.sh
+  # Reload library.sh to reset PHPVER
+  source /usr/local/etc/library.sh
 fi
 
 # refresh completions

--- a/bin/ncp-update-nc.d/upgrade-php-trixie-8.3.sh
+++ b/bin/ncp-update-nc.d/upgrade-php-trixie-8.3.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source /usr/local/etc/library.sh
+
+echo "Refreshing PHP repository for trixie..."
+export DEBIAN_FRONTEND=noninteractive
+
+# Refresh sury repo for trixie
+wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+echo "deb https://packages.sury.org/php/ ${RELEASE%-security} main" > /etc/apt/sources.list.d/php.list
+apt-get update
+
+echo "PHP ${PHPVER} repository updated for trixie."

--- a/bin/ncp/CONFIG/nc-datadir.sh
+++ b/bin/ncp/CONFIG/nc-datadir.sh
@@ -8,6 +8,10 @@
 # More at https://ownyourbits.com/2017/03/13/nextcloudpi-gets-nextcloudpi-config/
 #
 
+log_step() {
+  echo "[$(date -Is)] $*"
+}
+
 is_active()
 {
   local SRCDIR
@@ -112,6 +116,10 @@ configure()
     btrfs subvolume create "${BASEDIR}"
   }
 
+  log_step "setting nc config: datadirectory"
+  # first set in config the new value, because occ checks if the current datadir exists
+  ncc config:system:set datadirectory --value="${DATADIR}"
+
   # use encryption, if selected
   if is_active_app nc-encrypt; then
     # if we have encryption AND BTRFS, then store ncdata_enc in the subvolume
@@ -123,12 +131,7 @@ configure()
   fi
   chown www-data: "${DATADIR}"
 
-  # datadir
-  ncc config:system:set datadirectory  --value="${DATADIR}" \
-  || sed -i "s|'datadirectory' =>.*|'datadirectory' => '${DATADIR}',|" "${NCDIR?}"/config/config.php
-
-  ncc config:system:set logfile --value="${DATADIR}/nextcloud.log" \
-  || sed -i "s|'logfile' =>.*|'logfile' => '${DATADIR}/nextcloud.log',|" "${NCDIR?}"/config/config.php
+  ncc config:system:set logfile --value="${DATADIR}/nextcloud.log"
   set_ncpcfg datadir "${DATADIR}"
 
   # tmp upload dir

--- a/bin/ncp/CONFIG/nc-datadir.sh
+++ b/bin/ncp/CONFIG/nc-datadir.sh
@@ -8,10 +8,6 @@
 # More at https://ownyourbits.com/2017/03/13/nextcloudpi-gets-nextcloudpi-config/
 #
 
-log_step() {
-  echo "[$(date -Is)] $*"
-}
-
 is_active()
 {
   local SRCDIR
@@ -116,7 +112,6 @@ configure()
     btrfs subvolume create "${BASEDIR}"
   }
 
-  log_step "setting nc config: datadirectory"
   # first set in config the new value, because occ checks if the current datadir exists
   ncc config:system:set datadirectory --value="${DATADIR}"
 

--- a/bin/ncp/CONFIG/nc-init.sh
+++ b/bin/ncp/CONFIG/nc-init.sh
@@ -180,7 +180,6 @@ EOF
   if ! is_more_recent_than "21.0.0" "${ncver}"; then
     ncc app:install notify_push
     ncc app:enable  notify_push
-    test -f /.ncp-image || start_notify_push # don't start during build
   fi
 
   # previews
@@ -215,6 +214,9 @@ EOF
   test -f /usr/local/bin/nextcloud-domain.sh && {
     test -f /.ncp-image || bash /usr/local/bin/nextcloud-domain.sh
   }
+
+  # start notify_push after NC is fully configured
+  test -f /.ncp-image || start_notify_push # don't start during build
 
   # dettach mysql during the build
   if [[ "${db_pid}" != "" ]]; then

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -76,6 +76,15 @@ configure()
   install_template "php/pool.d.www.conf.sh" "$CONF"
   [[ "$CONF_VALUE"  == "$(cat "$CONF")"   ]] || require_fpm_restart=true
 
+  # PHP-FPM SYSTEMD DROP-IN (ReadWritePaths for ProtectSystem=full)
+  local DROPIN=/etc/systemd/system/php${PHPVER}-fpm.service.d/ncp.conf
+  CONF_VALUE="$(cat "$DROPIN" 2> /dev/null || true)"
+  install_template "systemd/php-fpm.service.d.ncp.conf.sh" "$DROPIN"
+  if [[ "$CONF_VALUE" != "$(cat "$DROPIN")" ]]; then
+    systemctl daemon-reload
+    require_fpm_restart=true
+  fi
+
   local CONF=/etc/mysql/mariadb.conf.d/91-ncp.cnf
   CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
   install_template "mysql/91-ncp.cnf.sh" "$CONF"

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -76,15 +76,6 @@ configure()
   install_template "php/pool.d.www.conf.sh" "$CONF"
   [[ "$CONF_VALUE"  == "$(cat "$CONF")"   ]] || require_fpm_restart=true
 
-  # PHP-FPM SYSTEMD DROP-IN (ReadWritePaths for ProtectSystem=full)
-  local DROPIN=/etc/systemd/system/php${PHPVER}-fpm.service.d/ncp.conf
-  CONF_VALUE="$(cat "$DROPIN" 2> /dev/null || true)"
-  install_template "systemd/php-fpm.service.d.ncp.conf.sh" "$DROPIN"
-  if [[ "$CONF_VALUE" != "$(cat "$DROPIN")" ]]; then
-    systemctl daemon-reload
-    require_fpm_restart=true
-  fi
-
   local CONF=/etc/mysql/mariadb.conf.d/91-ncp.cnf
   CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
   install_template "mysql/91-ncp.cnf.sh" "$CONF"

--- a/bin/ncp/NETWORKING/SSH.sh
+++ b/bin/ncp/NETWORKING/SSH.sh
@@ -17,7 +17,12 @@ install() {
   else
     echo 'PermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
   fi
-  systemctl reload ssh
+  # On Debian 13+ SSH is socket-activated, reload via socket
+  if systemctl is-active ssh.socket &>/dev/null; then
+    systemctl restart ssh
+  else
+    systemctl reload ssh
+  fi
  }
 
 is_active()

--- a/bin/ncp/NETWORKING/freeDNS.sh
+++ b/bin/ncp/NETWORKING/freeDNS.sh
@@ -7,10 +7,25 @@
 #
 
 
-install()
-{
-  apt-get update
-  apt-get install --no-install-recommends -y dnsutils
+wait_for_dpkg() {
+  local tries=0
+  while fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock >/dev/null 2>&1; do
+    echo "dpkg locked, waiting..."
+    fuser -v /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock 2>/dev/null || true
+    sleep 2
+    tries=$((tries + 1))
+    if [[ $tries -ge 150 ]]; then
+      echo "dpkg lock timeout"
+      return 1
+    fi
+  done
+}
+
+install() {
+  wait_for_dpkg || return 1
+  apt-get update || return 1
+  wait_for_dpkg || return 1
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y dnsutils || return 1
 }
 
 configure() 

--- a/bin/ncp/NETWORKING/letsencrypt.sh
+++ b/bin/ncp/NETWORKING/letsencrypt.sh
@@ -62,6 +62,8 @@ configure()
     local key_path="$(grep SSLCertificateKeyFile "${nc_vhostcfg}" | awk '{ print $2 }')"
     sed -i "s|SSLCertificateFile.*|SSLCertificateFile ${cert_path}|"      "${ncp_vhostcfg}"
     sed -i "s|SSLCertificateKeyFile.*|SSLCertificateKeyFile ${key_path}|" "${ncp_vhostcfg}"
+    # Enable OCSP stapling with valid Let's Encrypt certificate
+    sed -i 's/SSLUseStapling.*$/SSLUseStapling          on/' /etc/apache2/conf-available/http2.conf
     apachectl -k graceful
     echo "letsencrypt certificates disabled. Using self-signed certificates instead."
     exit 0
@@ -134,6 +136,8 @@ EOF
       }
     done
     set-nc-domain "$DOMAIN"
+    # Enable OCSP stapling with valid Let's Encrypt certificate
+    sed -i 's/SSLUseStapling.*$/SSLUseStapling          on/' /etc/apache2/conf-available/http2.conf
 
     apachectl -k graceful
     rm -rf $ncdir/.well-known

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -14,7 +14,8 @@ export NCDIR=/var/www/nextcloud
 export ncc=/usr/local/bin/ncc
 export NCPCFG=${NCPCFG:-etc/ncp.cfg}
 export ARCH="$(dpkg --print-architecture)"
-export DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG['"'dbtableprefix'"'];' || echo 'oc_')"
+# 2>/dev/null suppresses stderr-Output if PHP is not yet installed (new system)
+export DB_PREFIX="$(php -r 'include("/var/www/nextcloud/config/config.php"); echo $CONFIG['"'dbtableprefix'"'];' 2>/dev/null || echo 'oc_')"
 [[ "${ARCH}" =~ ^(armhf|arm)$ ]] && ARCH="armv7"
 [[ "${ARCH}" == "arm64" ]] && ARCH=aarch64
 [[ "${ARCH}" == "amd64" ]] && ARCH=x86_64
@@ -55,8 +56,10 @@ command -v jq &>/dev/null || {
 NCLATESTVER=$(jq -r .nextcloud_version < "$NCPCFG")
 PHPVER=$(     jq -r .php_version       < "$NCPCFG")
 RELEASE=$(    jq -r .release           < "$NCPCFG")
-# the default repo in bullseye is bullseye-security
-grep -Eh '^deb ' /etc/apt/sources.list | grep "${RELEASE}-security" > /dev/null && RELEASE="${RELEASE}-security"
+# check also /etc/apt/sources.list.d/ in Trixie
+grep -Eh '^deb ' /etc/apt/sources.list 2>/dev/null | grep "${RELEASE}-security" > /dev/null \
+  || grep -Eh '^deb ' /etc/apt/sources.list.d/*.list 2>/dev/null | grep "${RELEASE}-security" > /dev/null \
+  && RELEASE="${RELEASE}-security"
 command -v ncc &>/dev/null && NCVER="$(ncc status 2>/dev/null | grep "version:" | awk '{ print $3 }')"
 
 function configure_app()

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -179,6 +179,8 @@ function start_notify_push()
     if [[ -f /.docker-image ]]; then
       NEXTCLOUD_URL=https://localhost sudo -E -u www-data "/var/www/nextcloud/apps/notify_push/bin/${ARCH}/notify_push" --allow-self-signed /var/www/nextcloud/config/config.php &>/dev/null &
     else
+      # load generated systemd-unit
+      systemctl daemon-reload
       systemctl enable --now notify_push
     fi
     sleep 5 # apparently we need to make sure we wait until the database is written or something

--- a/etc/library.sh
+++ b/etc/library.sh
@@ -603,8 +603,24 @@ function clear_password_fields()
 
 function apt_install()
 {
+  wait_for_dpkg
   apt-get update --allow-releaseinfo-change
+  wait_for_dpkg
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o Dpkg::Options::=--force-confdef -o Dpkg::Options::="--force-confold" "$@"
+}
+
+function wait_for_dpkg() {
+  local tries=0
+  while fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock >/dev/null 2>&1; do
+    echo "dpkg locked, waiting..."
+    fuser -v /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock 2>/dev/null || true
+    sleep 2
+    tries=$((tries + 1))
+    if [[ $tries -ge 150 ]]; then
+      echo "dpkg lock timeout"
+      return 1
+    fi
+  done
 }
 
 function is_docker() {

--- a/etc/ncp-templates/apache2/http2.conf.sh
+++ b/etc/ncp-templates/apache2/http2.conf.sh
@@ -22,7 +22,7 @@ SSLCompression          off
 SSLSessionTickets       on
 
 # OCSP Stapling
-SSLUseStapling          on
+SSLUseStapling          off
 SSLStaplingResponderTimeout 5
 SSLStaplingReturnResponderErrors off
 SSLStaplingCache        shmcb:/var/run/ocsp(128000)

--- a/etc/ncp-templates/mysql/91-ncp.cnf.sh
+++ b/etc/ncp-templates/mysql/91-ncp.cnf.sh
@@ -14,9 +14,6 @@ fi
 cat <<EOF
 [mysqld]
 transaction_isolation = READ-COMMITTED
-innodb_large_prefix=true
-innodb_file_per_table=1
-innodb_file_format=barracuda
 max_allowed_packet=256M
 
 [mysqldump]
@@ -26,7 +23,6 @@ max_allowed_packet = 256M
 # innodb settings
 skip-name-resolve
 innodb_buffer_pool_size = ${INNODB_BUFFER_POOL_SIZE}
-innodb_buffer_pool_instances = 1
 innodb_flush_log_at_trx_commit = 2
 innodb_log_buffer_size = 32M
 innodb_max_dirty_pages_pct = 90

--- a/etc/ncp-templates/systemd/php-fpm.service.d.ncp.conf.sh
+++ b/etc/ncp-templates/systemd/php-fpm.service.d.ncp.conf.sh
@@ -4,14 +4,36 @@
 # that are otherwise blocked by ProtectSystem=full in the upstream
 # php-fpm service unit (introduced in php8.x Debian packages).
 #
-# ProtectSystem=full makes /usr, /boot and /etc read-only for the
-# php-fpm process. ReadWritePaths carves out explicit exceptions.
+# ProtectSystem=full creates a private mount namespace to make /usr,
+# /boot and /etc read-only for the php-fpm process.
+#
+# In unprivileged LXC containers, non-root users cannot create mount
+# namespaces (unshare CLONE_NEWNS is blocked by the kernel), so
+# ProtectSystem=full causes php-fpm to fail with status=226/NAMESPACE.
+# In that case we disable ProtectSystem entirely. Security is still
+# provided by Unix file permissions (cfg files are root:www-data 660)
+# and LXC container isolation.
+#
+# On bare-metal, VMs, and privileged LXC, ReadWritePaths is used to
+# carve out targeted exceptions while keeping the rest of the
+# hardening intact.
 
 set -e
 source /usr/local/etc/library.sh
 
-cat <<EOF
+if is_lxc && ! sudo -u www-data unshare --mount true 2>/dev/null; then
+  # Unprivileged LXC: namespace operations not permitted for non-root.
+  # Disable ProtectSystem to prevent php-fpm failing with 226/NAMESPACE.
+  cat <<EOF
+[Service]
+ProtectSystem=false
+EOF
+else
+  # Bare-metal, VM, or privileged/nested LXC:
+  # Keep ProtectSystem=full but allow writes to NCP-specific paths.
+  cat <<EOF
 [Service]
 ReadWritePaths=/usr/local/etc/ncp-config.d
 ReadWritePaths=/var/www/ncp-web
 EOF
+fi

--- a/etc/ncp-templates/systemd/php-fpm.service.d.ncp.conf.sh
+++ b/etc/ncp-templates/systemd/php-fpm.service.d.ncp.conf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# systemd drop-in for php-fpm to allow write access to NCP paths
+# that are otherwise blocked by ProtectSystem=full in the upstream
+# php-fpm service unit (introduced in php8.x Debian packages).
+#
+# ProtectSystem=full makes /usr, /boot and /etc read-only for the
+# php-fpm process. ReadWritePaths carves out explicit exceptions.
+
+set -e
+source /usr/local/etc/library.sh
+
+cat <<EOF
+[Service]
+ReadWritePaths=/usr/local/etc/ncp-config.d
+ReadWritePaths=/var/www/ncp-web
+EOF

--- a/etc/ncp.cfg
+++ b/etc/ncp.cfg
@@ -1,5 +1,5 @@
 {
 	"nextcloud_version": "33.0.2",
 	"php_version": "8.3",
-	"release": "bookworm"
+	"release": "trixie"
 }

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,10 @@ rm /usr/local/etc/ncp-config.d/nc-nextcloud.cfg    # armbian overlay is ro
 systemctl restart mysqld # TODO this shouldn't be necessary, but somehow it's needed in Debian 9.6. Fixme
 install_app    ncp.sh
 run_app_unsafe bin/ncp/CONFIG/nc-init.sh
+# notify_push was skipped during nc-init because /.ncp-image was set
+# start it now explicitly
+[[ -f /.docker-image ]] || start_notify_push
+
 echo 'Moving data directory to a more sensible location'
 df -h
 mkdir -p /opt/ncdata

--- a/lamp.sh
+++ b/lamp.sh
@@ -66,6 +66,11 @@ install()
 
     install_template "php/opcache.ini.sh" "/etc/php/${PHPVER}/mods-available/opcache.ini" --defaults
 
+    # systemd drop-in: allow write access to NCP paths blocked by ProtectSystem=full
+    install_template "systemd/php-fpm.service.d.ncp.conf.sh" \
+      "/etc/systemd/system/php${PHPVER}-fpm.service.d/ncp.conf"
+    systemctl daemon-reload
+
     a2enmod http2
     a2enconf http2
     a2enmod proxy_fcgi setenvif

--- a/lamp.sh
+++ b/lamp.sh
@@ -102,7 +102,8 @@ install()
   done
 
   cd /tmp
-  mysql_secure_installation <<EOF
+  SECURE_INSTALL="$(command -v mariadb-secure-installation || command -v mysql_secure_installation)"
+  "$SECURE_INSTALL" <<EOF
 $DBPASSWD
 y
 $DBPASSWD

--- a/update.sh
+++ b/update.sh
@@ -183,10 +183,6 @@ install_template "systemd/php-fpm.service.d.ncp.conf.sh" \
 # update old images
 ./run_update_history.sh "$UPDATESDIR"
 
-# reload systemd after drop-in changes
-systemctl daemon-reload
-service "php${PHPVER}-fpm" restart
-
 # update to the latest NC version
 is_active_app nc-autoupdate-nc && run_app nc-autoupdate-nc
 

--- a/update.sh
+++ b/update.sh
@@ -172,11 +172,20 @@ if is_docker; then
   cp build/docker/{lamp/010lamp,nextcloud/020nextcloud,nextcloudpi/000ncp} /etc/services-enabled.d
 fi
 
+# PHP-FPM systemd drop-in: allow write access to NCP paths blocked by ProtectSystem=full
+# (introduced in php8.x Debian packages via systemd hardening)
+install_template "systemd/php-fpm.service.d.ncp.conf.sh" \
+  "/etc/systemd/system/php${PHPVER}-fpm.service.d/ncp.conf"
+
 # only live updates from here
 [[ -f /.ncp-image ]] && exit 0
 
 # update old images
 ./run_update_history.sh "$UPDATESDIR"
+
+# reload systemd after drop-in changes
+systemctl daemon-reload
+service "php${PHPVER}-fpm" restart
 
 # update to the latest NC version
 is_active_app nc-autoupdate-nc && run_app nc-autoupdate-nc


### PR DESCRIPTION
# Description
This feature should update Debian 12 (bookworm) to Debian 13 (trixie).
The security support for Debian 12 end on 10 June 2026. With Debian LTS supports ends 20 August 2028.

# Changes
- switch to trixie dist repos
- suppresses stderr-Output if PHP is not yet installed (new system)
- adoption for maria db install command
- OSCP stapling
    - Disable OCSP stapling for self-signed certs - fixes OpenSSL 3.5 incompatibility on trixie
    - Enable OCSP stapling with valid Let's Encrypt certificate
- ssh: reload via socket on trixie
- dist-upgrade: remove switch to systemd-resolved for lxc enviroments, it breaks DNS

# Not changed
- PHP version 8.3. is unchanged

# Tests
## LXC
### Install on plain Debian 13 LXC
- ncp-config → UPDATES → nc-update-nextcloud 33.0.2 -> 33.0.3
- ncp-config → BACKUP → nc-backup
- ncp-config → DATABASE → nc-database → move db dir
- ncp-config → UPDATES → unattended-upgrades

### Dist upgrade on NCP 1.57.1, NC 33.0.2
- ncp-config → UPDATES → nc-update-nextcloud 33.0.2 -> 33.0.3
- ncp-config → BACKUP → nc-backup
- ncp-config → UPDATES → nc-update-nc-apps
- ncp-config → UPDATES → unattended-upgrades
- Check for maria db warn/errors (journalctl -u mariadb --no-pager | grep -i 'warn\|error')