### PR TITLE
fix for is_app_enabled(): replace hard coded 'previewgenerator'

### DIFF
--- a/etc/library.sh
+++ b/etc/library.sh
@@ -503,7 +503,7 @@ function is_more_recent_than()
 function is_app_enabled()
 {
   local app="$1"
-  ncc app:list --output json | jq -r '.enabled | keys | .[]' | grep '^previewgenerator$' > /dev/null 2> /dev/null
+  ncc app:list --output json | jq -r '.enabled | keys | .[]' | grep "^${app}$" > /dev/null 2> /dev/null
 }
 
 function check_distro()


### PR DESCRIPTION
# Description
During the update from NC 33.0.2 to NC 33.0.3 using ncp (ncp-config), the update kept failing without any apparent error message.
I had installed PreviewGenerator on my instance but had not activated it.

**Workaround**: If PreviewGenerator is installed before the update, the error does not occur.

- [X] I have verified that this is not a Nextcloud error.
- [X] I believe that is an NCP error.

# Details
In etc/library.sh the function is_app_enabled() ignores its argument and always checks for previewgenerator instead of the app passed as $1. This causes is_app_enabled notify_push to return the wrong result depending on whether previewgenerator is enabled, leading nc-update-nextcloud to attempt app:install notify_push even when it is already installed — which fails and triggers a rollback due to set -eE.

# Debug information
- NCP-version 1.57.1
- NC 33.0.2
- LXC