### PR TITLE
Make pm.max_requests configurable

### DIFF
--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -48,10 +48,10 @@ tmpl_php_threads() {
   [[ $PHPTHREADS -eq 0 ]] && PHPTHREADS=$(( TOTAL_MEM / ( 100 * 1024 * 1024 ) ))
   # Minimum 16
   [[ $PHPTHREADS -lt 16 ]] && PHPTHREADS=16
-   echo -n "$PHPTHREADS"
+  echo -n "$PHPTHREADS"
 }
 
-tmpl_php_maxrequests() {
+tmpl_php_max_requests() {
   local PHPMAXREQUESTS="$(find_app_param nc-limits PHPMAXREQUESTS)"
   [[ $PHPMAXREQUESTS -eq 0 ]] && PHPMAXREQUESTS=500
   echo -n "$PHPMAXREQUESTS"
@@ -65,7 +65,7 @@ configure()
   file /bin/bash | grep 64-bit > /dev/null || TOTAL_MEM="$(( 1024 * 1024 * 1024 * 4 ))"
   local AUTOMEM=$(( TOTAL_MEM * 75 / 100 ))
 
-# MAX FILESIZE & MAX PHP MEMORY
+# PHP MAX FILESIZE & PHP MAX MEMORY
   local require_fpm_restart=false
   local CONF=/etc/php/${PHPVER}/fpm/conf.d/90-ncp.ini
   local CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
@@ -74,11 +74,11 @@ configure()
   install_template "php/90-ncp.ini.sh" "$CONF"
   [[ "$CONF_VALUE" == "$(cat "$CONF")" ]] || require_fpm_restart=true
 
-  # MAX PHP THREADS & MAX REQUESTS
+  # PHP THREADS & PHP MAX REQUESTS
   local CONF=/etc/php/${PHPVER}/fpm/pool.d/www.conf
   CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
   echo "Using $(tmpl_php_threads) PHP threads"
-  echo "Using $(tmpl_php_maxrequests) for PHP max requests"
+  echo "Using $(tmpl_php_max_requests) for PHP max requests"
   install_template "php/pool.d.www.conf.sh" "$CONF"
   [[ "$CONF_VALUE"  == "$(cat "$CONF")"   ]] || require_fpm_restart=true
 

--- a/bin/ncp/CONFIG/nc-limits.sh
+++ b/bin/ncp/CONFIG/nc-limits.sh
@@ -51,6 +51,12 @@ tmpl_php_threads() {
    echo -n "$PHPTHREADS"
 }
 
+tmpl_php_maxrequests() {
+  local PHPMAXREQUESTS="$(find_app_param nc-limits PHPMAXREQUESTS)"
+  [[ $PHPMAXREQUESTS -eq 0 ]] && PHPMAXREQUESTS=500
+  echo -n "$PHPMAXREQUESTS"
+}
+
 configure()
 {
   # Set auto memory limit to 75% of the total memory
@@ -59,20 +65,20 @@ configure()
   file /bin/bash | grep 64-bit > /dev/null || TOTAL_MEM="$(( 1024 * 1024 * 1024 * 4 ))"
   local AUTOMEM=$(( TOTAL_MEM * 75 / 100 ))
 
-  # MAX FILESIZE
-
-  # MAX PHP MEMORY
+# MAX FILESIZE & MAX PHP MEMORY
   local require_fpm_restart=false
   local CONF=/etc/php/${PHPVER}/fpm/conf.d/90-ncp.ini
   local CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
+  echo "Using $(tmpl_php_max_filesize) for PHP max filesize"
   echo "Using $(tmpl_php_max_memory) for PHP max memory"
   install_template "php/90-ncp.ini.sh" "$CONF"
   [[ "$CONF_VALUE" == "$(cat "$CONF")" ]] || require_fpm_restart=true
 
-  # MAX PHP THREADS
+  # MAX PHP THREADS & MAX REQUESTS
   local CONF=/etc/php/${PHPVER}/fpm/pool.d/www.conf
   CONF_VALUE="$(cat "$CONF" 2> /dev/null || true)"
   echo "Using $(tmpl_php_threads) PHP threads"
+  echo "Using $(tmpl_php_maxrequests) for PHP max requests"
   install_template "php/pool.d.www.conf.sh" "$CONF"
   [[ "$CONF_VALUE"  == "$(cat "$CONF")"   ]] || require_fpm_restart=true
 

--- a/etc/ncp-config.d/l10n/nc-limits/de.json
+++ b/etc/ncp-config.d/l10n/nc-limits/de.json
@@ -1,3 +1,10 @@
-{"translations": {
-    "nc-limits": "Systembegrenzungen"
-}}
+{
+    "translations": {
+        "nc-limits": "Systembegrenzungen",
+        "MAXFILESIZE": "Maximale Dateigröße",
+        "MEMORYLIMIT": "Speicherlimit",
+        "PHPTHREADS": "PHP-Threads",
+        "PHPMAXREQUESTS": "Max. Anfragen vor Worker-Rotation",
+        "REDISMEM": "Redis-Speicher"
+    }
+}

--- a/etc/ncp-config.d/l10n/nc-limits/es.json
+++ b/etc/ncp-config.d/l10n/nc-limits/es.json
@@ -4,6 +4,7 @@
         "MAXFILESIZE":"Tamaño máximo de archivo en subida",
         "MEMORYLIMIT": "Límite de memoria",
         "PHPTHREADS": "Hilos PHP",
+        "PHPMAXREQUESTS": "Máx. de solicitudes antes de rotar el worker",
         "REDISMEM": "Memoria Redis",
         "Set PHP threads to 0 in order to use all cores": "Configura los hilos a 0 para usar todos los cores",
         "nc-limits": "nc-limits"

--- a/etc/ncp-config.d/l10n/nc-limits/pt.json
+++ b/etc/ncp-config.d/l10n/nc-limits/pt.json
@@ -4,6 +4,7 @@
         "MAXFILESIZE":"Tamanho máximo de arquivo para upload",
         "MEMORYLIMIT": "Limite  de memória",
         "PHPTHREADS": "THREADS PHP",
+        "PHPMAXREQUESTS": "Máx. de requisições antes da rotação do worker",
         "REDISMEM": "Memória Redis",
         "Set PHP threads to 0 in order to use all cores": "Configure as THREADS PHP à 0 para usar todas as cores",
         "nc-limits": "nc-limites"

--- a/etc/ncp-config.d/l10n/nc-limits/ru.json
+++ b/etc/ncp-config.d/l10n/nc-limits/ru.json
@@ -1,1 +1,9 @@
-{"translations":{"MAXFILESIZE":"Максимальный размер файла","MEMORYLIMIT":"Ограничение памяти","PHPTHREADS":"PHP потоки","REDISMEM":"REDIS память"}}
+{
+    "translations": {
+        "MAXFILESIZE": "Максимальный размер файла",
+        "MEMORYLIMIT": "Ограничение памяти",
+        "PHPTHREADS": "PHP потоки",
+        "PHPMAXREQUESTS": "Макс. запросов до ротации воркера",
+        "REDISMEM": "REDIS память"
+    }
+}

--- a/etc/ncp-config.d/l10n/nc-limits/zh.json
+++ b/etc/ncp-config.d/l10n/nc-limits/zh.json
@@ -4,6 +4,7 @@
         "MAXFILESIZE": "最大文件大小（<=2G）",
         "MEMORYLIMIT": "內存限制",
         "PHPTHREADS": "PHP線程",
+        "PHPMAXREQUESTS": "Worker 重启前的最大请求数",
         "REDISMEM": "REDIS記憶大小",
         "Examples: 200M or 2G. Write 0 for autoconfig": "例如：輸入200M或是2G。若要讓系統自行設定，請輸入0",
         "nc-limits": "修改NCP系統限制"

--- a/etc/ncp-config.d/nc-limits.cfg
+++ b/etc/ncp-config.d/nc-limits.cfg
@@ -28,6 +28,13 @@
       "suggest": "0"
     },
     {
+      "id": "PHPMAXREQUESTS",
+      "name": "Max. requests before worker rotation",
+      "value": "500",
+      "default": "500",
+      "suggest": "500"
+    },
+    {
       "id": "REDISMEM",
       "name": "Redis memory",
       "value": "0",

--- a/etc/ncp-templates/php/pool.d.www.conf.sh
+++ b/etc/ncp-templates/php/pool.d.www.conf.sh
@@ -8,10 +8,11 @@ PHPVER="${PHPVER?ERROR: PHPVER variable unset!}"
 if [[ "$1" == "--defaults" ]] || ! [[ -f "${BINDIR}/CONFIG/nc-limits.sh" ]]
 then
   echo "INFO: Restoring template to default settings" >&2
-
   PHPTHREADS=16
+  PHPMAXREQUESTS=500
 else
   PHPTHREADS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_threads)"
+  PHPMAXREQUESTS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_maxrequests)"
 fi
 
 
@@ -27,6 +28,7 @@ pm.max_children = ${PHPTHREADS}
 pm.start_servers = 4
 pm.min_spare_servers = 4
 pm.max_spare_servers = 8
+pm.max_requests = ${PHPMAXREQUESTS}
 pm.status_path = /status
 slowlog = log/\$pool.log.slow
 EOF

--- a/etc/ncp-templates/php/pool.d.www.conf.sh
+++ b/etc/ncp-templates/php/pool.d.www.conf.sh
@@ -12,7 +12,7 @@ then
   PHPMAXREQUESTS=500
 else
   PHPTHREADS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_threads)"
-  PHPMAXREQUESTS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_maxrequests)"
+  PHPMAXREQUESTS="$(source "${BINDIR}/CONFIG/nc-limits.sh"; tmpl_php_max_requests)"
 fi
 
 

--- a/updates/1.58.1.sh
+++ b/updates/1.58.1.sh
@@ -1,0 +1,9 @@
+  #!/usr/bin/env bash
+
+set -euo pipefail
+
+source /usr/local/etc/library.sh
+
+install_template "php/pool.d.www.conf.sh" "/etc/php/${PHPVER}/fpm/pool.d/www.conf"
+
+systemctl daemon-reload


### PR DESCRIPTION
Untested, please review carefully. AI used for translations only.

Given how the config mechanism works, it is impossible to set the value to zero (for disabling the limit, the old behavior). I guess this is acceptable for now.

Anyways, the whole config mechanism is a bit wild. The default value lives in three places. I think in an ideal solution, there would be exactly one default defined in .cfg. One could think about displaying it in the ncp-config CLI, say, in gray, when the input field is emptied. Instead of 0, there could be a placeholder like 'auto', leaving 0 as actually possible value. Just thinking out loud.